### PR TITLE
Adding Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -61,7 +61,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-richar@maintainer.io.
+reports@bosonprotocol.io.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
Closes #4. I used my own email, here. There should be another one for bosonprotocol - something like community@bosonprotocol.io. Want to set this up before merging?