### PR TITLE
docs: Add contributing section, Gitter badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,15 @@ For an overview of the contracts and their responsibilities, see
 
 ## Contributing
 
-TODO: Add contribution notes.
+We welcome contributions! Until now, Boson Protocol has been largely worked on by a small dedicated team. However, the ultimate goal is for all of the Boson Protocol repositories to be fully owned by the community and contributors. Issues, pull requests, suggestions, and any sort of involvement are more than welcome.
+
+If you have noticed a bug, [file an issue](/issues). If you have a large pull request, we recommend filing an issue first; small PRs are always welcome.
+
+Questions are also welcome, as long as they are tech related. We can use them to improve our documentation.
+
+All PRs must pass all tests before being merged.
+
+By being in this community, you agree to the [Code of Conduct](CODE_OF_CONDUCT.md). Take a look at it, if you haven't already.
 
 ## License
 


### PR DESCRIPTION
This adds a contributing section to the main README, and a Gitter badge. I
would like to add a Contributing doc, too, talking about how to become a
maintainer; that will happen in another PR. If the Gitter Badge looks good,
I will add it across the other repositories. I also add two deps (git and
direnv) to the deps section.