### PR TITLE
Sanitize PR pipeline names before pushing pipelines.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -239,7 +239,7 @@ namespace :ci do
 
         t.target = configuration.concourse_team
         t.team = configuration.concourse_team
-        t.pipeline = "contracts-pr-#{branch}"
+        t.pipeline = "contracts-pr-#{to_pipeline_name(branch)}"
 
         t.config = 'pipelines/pr/pipeline.yaml'
 
@@ -298,4 +298,8 @@ end
 
 def pr_metadata_state
   pr_metadata_value("state")
+end
+
+def to_pipeline_name(string)
+  string.gsub(/[^a-zA-Z0-9_-]/, "_")
 end


### PR DESCRIPTION
Currently, for branch names such as `feat/xyz` or `release/123`, the pipeline builder fails since Concourse doesn't allow characters other than `a-zA-Z0-9_-`.

This PR sanitizes the branch name before creating the pipeline to work around this.