### PR TITLE
Move hooks out of router

### DIFF
--- a/contracts/BosonRouter.sol
+++ b/contracts/BosonRouter.sol
@@ -11,7 +11,6 @@ import "./interfaces/IERC20WithPermit.sol";
 import "./interfaces/IFundLimitsOracle.sol";
 import "./interfaces/IBosonRouter.sol";
 import "./interfaces/ICashier.sol";
-import "./ERC1155ERC721.sol";
 import "./UsingHelpers.sol";
 
 /**
@@ -33,7 +32,6 @@ contract BosonRouter is
 
     address public cashierAddress;
     address public voucherKernel;
-    address public tokensContractAddress;
     address public fundLimitsOracle;
 
     event LogOrderCreated(
@@ -44,20 +42,11 @@ contract BosonRouter is
         uint256 _correlationId
     );
 
-    event LogTokenContractSet(address _newTokenContract, address _triggeredBy);
-
     /**
      * @notice Acts as a modifier, but it's cheaper. Checking if a non-zero address is provided, otherwise reverts.
      */
     function notZeroAddress(address tokenAddress) private pure {
         require(tokenAddress != address(0), "0A"); //zero address
-    }
-
-    /**
-     * @notice Acts as a modifier, but it's cheaper. The only caller must be tokensContractAddress, otherwise reverts.
-     */
-    function onlyTokensContract() private view {
-        require(msg.sender == tokensContractAddress, "UT"); // Unauthorized token address
     }
 
     /**
@@ -98,17 +87,14 @@ contract BosonRouter is
 
     constructor(
         address _voucherKernel,
-        address _tokensContractAddress,
         address _fundLimitsOracle,
         address _cashierAddress
     ) {
         notZeroAddress(_voucherKernel);
-        notZeroAddress(_tokensContractAddress);
         notZeroAddress(_fundLimitsOracle);
         notZeroAddress(_cashierAddress);
 
         voucherKernel = _voucherKernel;
-        tokensContractAddress = _tokensContractAddress;
         fundLimitsOracle = _fundLimitsOracle;
         cashierAddress = _cashierAddress;
     }
@@ -709,292 +695,18 @@ contract BosonRouter is
         );
     }
 
-    /**
-     * @notice Hook which will be triggered when a _tokenIdVoucher will be transferred. Escrow funds should be allocated to the new owner.
-     * @param _from prev owner of the _tokenIdVoucher
-     * @param _to next owner of the _tokenIdVoucher
-     * @param _tokenIdVoucher _tokenIdVoucher that has been transferred
-     */
-    function _onERC721Transfer(
-        address _from,
-        address _to,
-        uint256 _tokenIdVoucher
-    ) external override {
-        onlyTokensContract();
-        uint256 tokenSupplyId =
-            IVoucherKernel(voucherKernel).getIdSupplyFromVoucher(
-                _tokenIdVoucher
-            );
-        uint8 paymentType =
-            IVoucherKernel(voucherKernel).getVoucherPaymentMethod(
-                tokenSupplyId
-            );
-
-        uint256 amount;
-        address tokenAddress;
-
-        (uint256 price, uint256 depositBu) =
-            IVoucherKernel(voucherKernel).getBuyerOrderCosts(tokenSupplyId);
-
-        if (paymentType == ETHETH) {
-            uint256 totalAmount = price.add(depositBu);
-
-            amount = ICashier(cashierAddress).getEscrowAmount(_from);
-            ICashier(cashierAddress).updateEscrowAmount(
-                _from,
-                amount.sub(totalAmount)
-            );
-
-            amount = ICashier(cashierAddress).getEscrowAmount(_to);
-            ICashier(cashierAddress).updateEscrowAmount(
-                _to,
-                amount.add(totalAmount)
-            );
-        }
-
-        if (paymentType == ETHTKN) {
-            amount = ICashier(cashierAddress).getEscrowAmount(_from);
-            ICashier(cashierAddress).updateEscrowAmount(
-                _from,
-                amount.sub(price)
-            );
-
-            amount = ICashier(cashierAddress).getEscrowAmount(_to);
-            ICashier(cashierAddress).updateEscrowAmount(_to, amount.add(price));
-
-            tokenAddress = IVoucherKernel(voucherKernel).getVoucherDepositToken(
-                tokenSupplyId
-            );
-
-            amount = ICashier(cashierAddress).getEscrowTokensAmount(
-                tokenAddress,
-                _from
-            );
-            ICashier(cashierAddress).updateEscrowTokensAmount(
-                tokenAddress,
-                _from,
-                amount.sub(depositBu)
-            );
-
-            amount = ICashier(cashierAddress).getEscrowTokensAmount(
-                tokenAddress,
-                _to
-            );
-            ICashier(cashierAddress).updateEscrowTokensAmount(
-                tokenAddress,
-                _to,
-                amount.add(depositBu)
-            );
-        }
-
-        if (paymentType == TKNETH) {
-            tokenAddress = IVoucherKernel(voucherKernel).getVoucherPriceToken(
-                tokenSupplyId
-            );
-
-            amount = ICashier(cashierAddress).getEscrowTokensAmount(
-                tokenAddress,
-                _from
-            );
-            ICashier(cashierAddress).updateEscrowTokensAmount(
-                tokenAddress,
-                _from,
-                amount.sub(price)
-            );
-
-            amount = ICashier(cashierAddress).getEscrowTokensAmount(
-                tokenAddress,
-                _to
-            );
-            ICashier(cashierAddress).updateEscrowTokensAmount(
-                tokenAddress,
-                _to,
-                amount.add(price)
-            );
-
-            amount = ICashier(cashierAddress).getEscrowAmount(_from);
-            ICashier(cashierAddress).updateEscrowAmount(
-                _from,
-                amount.sub(depositBu)
-            );
-
-            amount = ICashier(cashierAddress).getEscrowAmount(_to);
-            ICashier(cashierAddress).updateEscrowAmount(
-                _to,
-                amount.add(depositBu)
-            );
-        }
-
-        if (paymentType == TKNTKN) {
-            tokenAddress = IVoucherKernel(voucherKernel).getVoucherPriceToken(
-                tokenSupplyId
-            );
-
-            amount = ICashier(cashierAddress).getEscrowTokensAmount(
-                tokenAddress,
-                _from
-            );
-            ICashier(cashierAddress).updateEscrowTokensAmount(
-                tokenAddress,
-                _from,
-                amount.sub(price)
-            );
-
-            amount = ICashier(cashierAddress).getEscrowTokensAmount(
-                tokenAddress,
-                _to
-            );
-            ICashier(cashierAddress).updateEscrowTokensAmount(
-                tokenAddress,
-                _to,
-                amount.add(price)
-            );
-
-            tokenAddress = IVoucherKernel(voucherKernel).getVoucherDepositToken(
-                tokenSupplyId
-            );
-
-            amount = ICashier(cashierAddress).getEscrowTokensAmount(
-                tokenAddress,
-                _from
-            );
-            ICashier(cashierAddress).updateEscrowTokensAmount(
-                tokenAddress,
-                _from,
-                amount.sub(depositBu)
-            );
-
-            amount = ICashier(cashierAddress).getEscrowTokensAmount(
-                tokenAddress,
-                _to
-            );
-            ICashier(cashierAddress).updateEscrowTokensAmount(
-                tokenAddress,
-                _to,
-                amount.add(depositBu)
-            );
-        }
-
-        correlationIds[_to]++;
-    }
-
-    /**
-     * @notice Pre-validation when a transfer from the the Tokens contract is triggered. Only the whole supply is allowed for transfer, otherwise reverts.
-     * @param _from owner of the _tokenSupplyId
-     * @param _tokenSupplyId _tokenSupplyId which will be validated
-     * @param _value qty which is desired to be transferred
-     */
-    function _beforeERC1155Transfer(
-        address _from,
-        uint256 _tokenSupplyId,
-        uint256 _value
-    ) external view override {
-        onlyTokensContract();
-        uint256 _tokenSupplyQty =
-            IVoucherKernel(voucherKernel).getRemQtyForSupply(
-                _tokenSupplyId,
-                _from
-            );
-        require(_tokenSupplyQty == _value, "IQ"); //invalid qty
-    }
-
-    /**
-     * @notice After the transfer happens the _tokenSupplyId should be updated in the promise. Escrow funds for the seller's deposits (If in ETH) should be allocated to the new owner as well.
-     * @param _from prev owner of the _tokenSupplyId
-     * @param _to nex owner of the _tokenSupplyId
-     * @param _tokenSupplyId _tokenSupplyId for transfer
-     * @param _value qty which has been transferred
-     */
-    function _onERC1155Transfer(
-        address _from,
-        address _to,
-        uint256 _tokenSupplyId,
-        uint256 _value
-    ) external override {
-        onlyTokensContract();
-        uint8 paymentType =
-            IVoucherKernel(voucherKernel).getVoucherPaymentMethod(
-                _tokenSupplyId
-            );
-
-        uint256 depositSe;
-        uint256 totalAmount;
-        uint256 amount;
-
-        if (paymentType == ETHETH || paymentType == TKNETH) {
-            depositSe = IVoucherKernel(voucherKernel).getSellerDeposit(
-                _tokenSupplyId
-            );
-            totalAmount = depositSe.mul(_value);
-
-            amount = ICashier(cashierAddress).getEscrowAmount(_from);
-            ICashier(cashierAddress).updateEscrowAmount(
-                _from,
-                amount.sub(totalAmount)
-            );
-
-            amount = ICashier(cashierAddress).getEscrowAmount(_to);
-            ICashier(cashierAddress).updateEscrowAmount(
-                _to,
-                amount.add(totalAmount)
-            );
-        }
-
-        if (paymentType == ETHTKN || paymentType == TKNTKN) {
-            address tokenDepositAddress =
-                IVoucherKernel(voucherKernel).getVoucherDepositToken(
-                    _tokenSupplyId
-                );
-
-            depositSe = IVoucherKernel(voucherKernel).getSellerDeposit(
-                _tokenSupplyId
-            );
-            totalAmount = depositSe.mul(_value);
-
-            amount = ICashier(cashierAddress).getEscrowTokensAmount(
-                tokenDepositAddress,
-                _from
-            );
-            ICashier(cashierAddress).updateEscrowTokensAmount(
-                tokenDepositAddress,
-                _from,
-                amount.sub(totalAmount)
-            );
-
-            amount = ICashier(cashierAddress).getEscrowTokensAmount(
-                tokenDepositAddress,
-                _to
-            );
-            ICashier(cashierAddress).updateEscrowTokensAmount(
-                tokenDepositAddress,
-                _to,
-                amount.add(totalAmount)
-            );
-        }
-
-        IVoucherKernel(voucherKernel).setSupplyHolderOnTransfer(
-            _tokenSupplyId,
-            _to
-        );
-
-        correlationIds[_to]++;
-    }
-
     // // // // // // // //
     // UTILS
     // // // // // // // //
 
     /**
-     * @notice Set the address of the ERC1155ERC721 contract
-     * @param _tokensContractAddress   The address of the ERC1155ERC721 contract
+     * @notice Increment a seller or buyer's correlation Id
+     * @param _party   The address of the seller or buyer
      */
-    function setTokenContractAddress(address _tokensContractAddress)
+    function incrementCorrelationId(address _party) 
         external
         override
     {
-        onlyRouterOwner();
-        notZeroAddress(_tokensContractAddress);
-        tokensContractAddress = _tokensContractAddress;
-        emit LogTokenContractSet(_tokensContractAddress, msg.sender);
+         correlationIds[_party]++;
     }
 }

--- a/contracts/Cashier.sol
+++ b/contracts/Cashier.sol
@@ -895,8 +895,8 @@ contract Cashier is ICashier, UsingHelpers, ReentrancyGuard, Ownable, Pausable {
             );
 
             //Reduce _from escrow token amount and increase _to escrow token amount - deposit
-            escrowTokens[tokenAddress][_from] =  escrowTokens[tokenAddress][_from].sub(depositBu);
-            escrowTokens[tokenAddress][_to] =  escrowTokens[tokenAddress][_to].add(depositBu);
+            escrowTokens[tokenAddress][_from] = escrowTokens[tokenAddress][_from].sub(depositBu);
+            escrowTokens[tokenAddress][_to] = escrowTokens[tokenAddress][_to].add(depositBu);
 
         }
 
@@ -907,8 +907,8 @@ contract Cashier is ICashier, UsingHelpers, ReentrancyGuard, Ownable, Pausable {
         
 
             //Reduce _from escrow token amount and increase _to escrow token amount - price 
-            escrowTokens[tokenAddress][_from] =  escrowTokens[tokenAddress][_from].sub(price);
-            escrowTokens[tokenAddress][_to] =  escrowTokens[tokenAddress][_to].add(price);
+            escrowTokens[tokenAddress][_from] = escrowTokens[tokenAddress][_from].sub(price);
+            escrowTokens[tokenAddress][_to] = escrowTokens[tokenAddress][_to].add(price);
 
             //Reduce _from escrow amount and increase _to escrow amount - deposit
             escrow[_from] = escrow[_from].sub(depositBu);
@@ -922,16 +922,16 @@ contract Cashier is ICashier, UsingHelpers, ReentrancyGuard, Ownable, Pausable {
 
 
             //Reduce _from escrow token amount and increase _to escrow token amount - price 
-            escrowTokens[tokenAddress][_from] =  escrowTokens[tokenAddress][_from].sub(price);
-            escrowTokens[tokenAddress][_to] =  escrowTokens[tokenAddress][_to].add(price);
+            escrowTokens[tokenAddress][_from] = escrowTokens[tokenAddress][_from].sub(price);
+            escrowTokens[tokenAddress][_to] = escrowTokens[tokenAddress][_to].add(price);
 
             tokenAddress = IVoucherKernel(voucherKernel).getVoucherDepositToken(
                 tokenSupplyId
             );
 
             //Reduce _from escrow token amount and increase _to escrow token amount - deposit 
-            escrowTokens[tokenAddress][_from] =  escrowTokens[tokenAddress][_from].sub(depositBu);
-            escrowTokens[tokenAddress][_to] =  escrowTokens[tokenAddress][_to].add(depositBu);
+            escrowTokens[tokenAddress][_from] = escrowTokens[tokenAddress][_from].sub(depositBu);
+            escrowTokens[tokenAddress][_to] = escrowTokens[tokenAddress][_to].add(depositBu);
 
         }
    
@@ -982,8 +982,8 @@ contract Cashier is ICashier, UsingHelpers, ReentrancyGuard, Ownable, Pausable {
             totalAmount = depositSe.mul(_value);
 
             //Reduce _from escrow token amount and increase _to escrow token amount - deposit
-            escrowTokens[tokenDepositAddress][_from] =  escrowTokens[tokenDepositAddress][_from].sub(totalAmount);
-            escrowTokens[tokenDepositAddress][_to] =  escrowTokens[tokenDepositAddress][_to].add(totalAmount);
+            escrowTokens[tokenDepositAddress][_from] = escrowTokens[tokenDepositAddress][_from].sub(totalAmount);
+            escrowTokens[tokenDepositAddress][_to] = escrowTokens[tokenDepositAddress][_to].add(totalAmount);
         }
 
         IVoucherKernel(voucherKernel).setSupplyHolderOnTransfer(

--- a/contracts/Cashier.sol
+++ b/contracts/Cashier.sol
@@ -938,26 +938,7 @@ contract Cashier is ICashier, UsingHelpers, ReentrancyGuard, Ownable, Pausable {
         IBosonRouter(bosonRouterAddress).incrementCorrelationId(_to);
     }
 
-   /**
-     * @notice Pre-validation when a transfer from the the Tokens contract is triggered. Only the whole supply is allowed for transfer, otherwise reverts.
-     * @param _from owner of the _tokenSupplyId
-     * @param _tokenSupplyId _tokenSupplyId which will be validated
-     * @param _value qty which is desired to be transferred
-     */
-    function beforeERC1155Transfer(
-        address _from,
-        uint256 _tokenSupplyId,
-        uint256 _value
-    ) external view override onlyTokensContract {
-        uint256 _tokenSupplyQty =
-            IVoucherKernel(voucherKernel).getRemQtyForSupply(
-                _tokenSupplyId,
-                _from
-            );
-        require(_tokenSupplyQty == _value, "IQ"); //invalid qty
-    }
-
-     /**
+    /**
      * @notice After the transfer happens the _tokenSupplyId should be updated in the promise. Escrow funds for the seller's deposits (If in ETH) should be allocated to the new owner as well.
      * @param _from prev owner of the _tokenSupplyId
      * @param _to nex owner of the _tokenSupplyId

--- a/contracts/Cashier.sol
+++ b/contracts/Cashier.sol
@@ -10,6 +10,7 @@ import "@openzeppelin/contracts/utils/Address.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./interfaces/IVoucherKernel.sol";
 import "./interfaces/ICashier.sol";
+import "./interfaces/IBosonRouter.sol";
 import "./UsingHelpers.sol";
 
 /**
@@ -23,6 +24,7 @@ contract Cashier is ICashier, UsingHelpers, ReentrancyGuard, Ownable, Pausable {
 
     address public voucherKernel;
     address public bosonRouterAddress;
+    address public tokensContractAddress;
     bool public disasterState;
 
     enum PaymentType {PAYMENT, DEPOSIT_SELLER, DEPOSIT_BUYER}
@@ -34,6 +36,8 @@ contract Cashier is ICashier, UsingHelpers, ReentrancyGuard, Ownable, Pausable {
     uint256 internal constant CANCELFAULT_SPLIT = 2; //for POC purposes, this is hardcoded; e.g. each party gets depositSe / 2
 
     event LogBosonRouterSet(address _newBosonRouter, address _triggeredBy);
+
+    event LogTokenContractSet(address _newTokenContract, address _triggeredBy);
 
     event LogWithdrawal(address _caller, address _payee, uint256 _payment);
 
@@ -60,6 +64,14 @@ contract Cashier is ICashier, UsingHelpers, ReentrancyGuard, Ownable, Pausable {
 
     modifier notZeroAddress(address tokenAddress) {
         require(tokenAddress != address(0), "INVALID_TOKEN_ADDRESS");
+        _;
+    }
+
+    /**
+     * @notice The only caller must be tokensContractAddress, otherwise reverts.
+     */
+    modifier onlyTokensContract() {
+        require(msg.sender == tokensContractAddress, "UT"); // Unauthorized token address
         _;
     }
 
@@ -795,17 +807,20 @@ contract Cashier is ICashier, UsingHelpers, ReentrancyGuard, Ownable, Pausable {
     }
 
     /**
-     * @notice Update the amount in escrow of an address with the new value, based on VoucherSet/Voucher interaction
-     * @param _account  The address of an account to query
-     * @param _newAmount  New amount to be set
+     * @notice Set the address of the ERC1155ERC721 contract
+     * @param _tokensContractAddress   The address of the ERC1155ERC721 contract
      */
-    function updateEscrowAmount(address _account, uint256 _newAmount)
+    function setTokenContractAddress(address _tokensContractAddress)
         external
         override
-        onlyFromRouter
+        onlyOwner
     {
-        escrow[_account] = _newAmount;
+     
+        require(_tokensContractAddress != address(0), "UNSPECIFIED_ADDRESS"); //hex"20" FISSION.code(FISSION.Category.Find, FISSION.Status.NotFound_Unequal_OutOfRange)
+        tokensContractAddress = _tokensContractAddress;
+        emit LogTokenContractSet(_tokensContractAddress, msg.sender);
     }
+
 
     /**
      * @notice Update the amount in escrow of an address with the new value, based on VoucherSet/Voucher interaction
@@ -826,20 +841,6 @@ contract Cashier is ICashier, UsingHelpers, ReentrancyGuard, Ownable, Pausable {
      * @param _account  The address of an account to query
      * @param _newAmount  New amount to be set
      */
-    function updateEscrowTokensAmount(
-        address _token,
-        address _account,
-        uint256 _newAmount
-    ) external override onlyFromRouter {
-        escrowTokens[_token][_account] = _newAmount;
-    }
-
-    /**
-     * @notice Update the amount in escrowTokens of an address with the new value, based on VoucherSet/Voucher interaction
-     * @param _token  The address of a token to query
-     * @param _account  The address of an account to query
-     * @param _newAmount  New amount to be set
-     */
     function addEscrowTokensAmount(
         address _token,
         address _account,
@@ -848,6 +849,169 @@ contract Cashier is ICashier, UsingHelpers, ReentrancyGuard, Ownable, Pausable {
         escrowTokens[_token][_account] =  escrowTokens[_token][_account].add(_newAmount);
     }
 
+    /**
+     * @notice Hook which will be triggered when a _tokenIdVoucher will be transferred. Escrow funds should be allocated to the new owner.
+     * @param _from prev owner of the _tokenIdVoucher
+     * @param _to next owner of the _tokenIdVoucher
+     * @param _tokenIdVoucher _tokenIdVoucher that has been transferred
+     */
+    function onERC721Transfer(
+        address _from,
+        address _to,
+        uint256 _tokenIdVoucher
+    ) external override onlyTokensContract {
+        address tokenAddress;
+
+        uint256 tokenSupplyId =
+            IVoucherKernel(voucherKernel).getIdSupplyFromVoucher(
+                _tokenIdVoucher
+            );
+
+        uint8 paymentType =
+            IVoucherKernel(voucherKernel).getVoucherPaymentMethod(
+                tokenSupplyId
+            );
+
+        (uint256 price, uint256 depositBu) =
+            IVoucherKernel(voucherKernel).getBuyerOrderCosts(tokenSupplyId);
+
+        if (paymentType == ETHETH) {
+            uint256 totalAmount = price.add(depositBu);
+
+            //Reduce _from escrow amount and increase _to escrow amount
+            escrow[_from] = escrow[_from].sub(totalAmount);
+            escrow[_to] = escrow[_to].add(totalAmount);
+        }
+
+
+        if (paymentType == ETHTKN) {
+
+            //Reduce _from escrow amount and increase _to escrow amount - price
+            escrow[_from] = escrow[_from].sub(price);
+            escrow[_to] = escrow[_to].add(price);
+
+            tokenAddress = IVoucherKernel(voucherKernel).getVoucherDepositToken(
+                tokenSupplyId
+            );
+
+            //Reduce _from escrow token amount and increase _to escrow token amount - deposit
+            escrowTokens[tokenAddress][_from] =  escrowTokens[tokenAddress][_from].sub(depositBu);
+            escrowTokens[tokenAddress][_to] =  escrowTokens[tokenAddress][_to].add(depositBu);
+
+        }
+
+        if (paymentType == TKNETH) {
+            tokenAddress = IVoucherKernel(voucherKernel).getVoucherPriceToken(
+                tokenSupplyId
+            );
+        
+
+            //Reduce _from escrow token amount and increase _to escrow token amount - price 
+            escrowTokens[tokenAddress][_from] =  escrowTokens[tokenAddress][_from].sub(price);
+            escrowTokens[tokenAddress][_to] =  escrowTokens[tokenAddress][_to].add(price);
+
+            //Reduce _from escrow amount and increase _to escrow amount - deposit
+            escrow[_from] = escrow[_from].sub(depositBu);
+            escrow[_to] = escrow[_to].add(depositBu);
+        }
+
+        if (paymentType == TKNTKN) {
+            tokenAddress = IVoucherKernel(voucherKernel).getVoucherPriceToken(
+                tokenSupplyId
+            );
+
+
+            //Reduce _from escrow token amount and increase _to escrow token amount - price 
+            escrowTokens[tokenAddress][_from] =  escrowTokens[tokenAddress][_from].sub(price);
+            escrowTokens[tokenAddress][_to] =  escrowTokens[tokenAddress][_to].add(price);
+
+            tokenAddress = IVoucherKernel(voucherKernel).getVoucherDepositToken(
+                tokenSupplyId
+            );
+
+            //Reduce _from escrow token amount and increase _to escrow token amount - deposit 
+            escrowTokens[tokenAddress][_from] =  escrowTokens[tokenAddress][_from].sub(depositBu);
+            escrowTokens[tokenAddress][_to] =  escrowTokens[tokenAddress][_to].add(depositBu);
+
+        }
+   
+        IBosonRouter(bosonRouterAddress).incrementCorrelationId(_to);
+    }
+
+   /**
+     * @notice Pre-validation when a transfer from the the Tokens contract is triggered. Only the whole supply is allowed for transfer, otherwise reverts.
+     * @param _from owner of the _tokenSupplyId
+     * @param _tokenSupplyId _tokenSupplyId which will be validated
+     * @param _value qty which is desired to be transferred
+     */
+    function beforeERC1155Transfer(
+        address _from,
+        uint256 _tokenSupplyId,
+        uint256 _value
+    ) external view override onlyTokensContract {
+        uint256 _tokenSupplyQty =
+            IVoucherKernel(voucherKernel).getRemQtyForSupply(
+                _tokenSupplyId,
+                _from
+            );
+        require(_tokenSupplyQty == _value, "IQ"); //invalid qty
+    }
+
+     /**
+     * @notice After the transfer happens the _tokenSupplyId should be updated in the promise. Escrow funds for the seller's deposits (If in ETH) should be allocated to the new owner as well.
+     * @param _from prev owner of the _tokenSupplyId
+     * @param _to nex owner of the _tokenSupplyId
+     * @param _tokenSupplyId _tokenSupplyId for transfer
+     * @param _value qty which has been transferred
+     */
+    function onERC1155Transfer(
+        address _from,
+        address _to,
+        uint256 _tokenSupplyId,
+        uint256 _value
+    ) external override onlyTokensContract {
+        uint8 paymentType =
+            IVoucherKernel(voucherKernel).getVoucherPaymentMethod(
+                _tokenSupplyId
+            );
+
+        uint256 depositSe;
+        uint256 totalAmount;
+
+        if (paymentType == ETHETH || paymentType == TKNETH) {
+            depositSe = IVoucherKernel(voucherKernel).getSellerDeposit(
+                _tokenSupplyId
+            );
+            totalAmount = depositSe.mul(_value);
+
+            //Reduce _from escrow amount and increase _to escrow amount
+            escrow[_from] = escrow[_from].sub(totalAmount);
+            escrow[_to] = escrow[_to].add(totalAmount);
+        }
+
+        if (paymentType == ETHTKN || paymentType == TKNTKN) {
+            address tokenDepositAddress =
+                IVoucherKernel(voucherKernel).getVoucherDepositToken(
+                    _tokenSupplyId
+                );
+
+            depositSe = IVoucherKernel(voucherKernel).getSellerDeposit(
+                _tokenSupplyId
+            );
+            totalAmount = depositSe.mul(_value);
+
+            //Reduce _from escrow token amount and increase _to escrow token amount - deposit
+            escrowTokens[tokenDepositAddress][_from] =  escrowTokens[tokenDepositAddress][_from].sub(totalAmount);
+            escrowTokens[tokenDepositAddress][_to] =  escrowTokens[tokenDepositAddress][_to].add(totalAmount);
+        }
+
+        IVoucherKernel(voucherKernel).setSupplyHolderOnTransfer(
+            _tokenSupplyId,
+            _to
+        );
+
+        IBosonRouter(bosonRouterAddress).incrementCorrelationId(_to);
+    }
 
     /**
      * @notice Only accept ETH via fallback from the BR Contract

--- a/contracts/Cashier.sol
+++ b/contracts/Cashier.sol
@@ -792,7 +792,7 @@ contract Cashier is ICashier, UsingHelpers, ReentrancyGuard, Ownable, Pausable {
 
     /**
      * @notice Set the address of the BR contract
-     * @param _bosonRouterAddress   The address of the Cashier contract
+     * @param _bosonRouterAddress   The address of the Boson Route contract
      */
     function setBosonRouterAddress(address _bosonRouterAddress)
         external

--- a/contracts/ERC1155ERC721.sol
+++ b/contracts/ERC1155ERC721.sol
@@ -97,11 +97,7 @@ contract ERC1155ERC721 is IERC1155, IERC721, IERC1155ERC721 {
             "UNAUTHORIZED_ST"
         ); //hex"10"FISSION.code(FISSION.Category.Permission, FISSION.Status.Disallowed_Stop)
 
-        ICashier(cashierAddress).beforeERC1155Transfer(
-            _from,
-            _tokenId,
-            _value
-        );
+        require(balances[_tokenId][_from] == _value, "IQ"); //invalid qty
 
         // SafeMath throws with insufficient funds or if _id is not valid (balance will be 0)
         balances[_tokenId][_from] = balances[_tokenId][_from].sub(_value);
@@ -308,11 +304,7 @@ contract ERC1155ERC721 is IERC1155, IERC721, IERC1155ERC721 {
             uint256 tokenId = _tokenIds[i];
             uint256 value = _values[i];
 
-            ICashier(cashierAddress).beforeERC1155Transfer(
-                _from,
-                tokenId,
-                value
-            );
+            require(balances[tokenId][_from] == value, "IQ"); //invalid qty
 
             // SafeMath throws with insufficient funds or if _id is not valid (balance will be 0)
             balances[tokenId][_from] = balances[tokenId][_from].sub(value);

--- a/contracts/ERC1155ERC721.sol
+++ b/contracts/ERC1155ERC721.sol
@@ -822,7 +822,7 @@ contract ERC1155ERC721 is IERC1155, IERC721, IERC1155ERC721 {
 
     /**
      * @notice Set the address of the cashier contract
-     * @param _cashierAddress   The Boson Router  contract
+     * @param _cashierAddress   The Cashier contract
      */
     function setCashierAddress(address _cashierAddress)
         external

--- a/contracts/ERC1155ERC721.sol
+++ b/contracts/ERC1155ERC721.sol
@@ -10,8 +10,8 @@ import "./interfaces/IERC1155TokenReceiver.sol";
 import "./interfaces/IERC721.sol";
 import "./interfaces/IERC721TokenReceiver.sol";
 import "./interfaces/IERC1155ERC721.sol";
-import "./interfaces/IBosonRouter.sol";
 import "./interfaces/IVoucherKernel.sol";
+import "./interfaces/ICashier.sol";
 
 //preparing for ERC-1066, ERC-1444, EIP-838
 
@@ -26,7 +26,7 @@ contract ERC1155ERC721 is IERC1155, IERC721, IERC1155ERC721 {
     //min security
     address public owner; //contract owner
     address public voucherKernelAddress; //address of the VoucherKernel contract
-    address public bosonRouterAddress; //address of the BosonRouter contract
+    address public cashierAddress; //address of the Cashier contract
 
     //standard reqs
     //ERC-1155
@@ -49,8 +49,7 @@ contract ERC1155ERC721 is IERC1155, IERC721, IERC1155ERC721 {
     //event URI(string _value, uint256 indexed _id);
 
     event LogVoucherKernelSet(address _newVoucherKernel, address _triggeredBy);
-
-    event LogBosonRouterSet(address _newBosonRouter, address _triggeredBy);
+    event LogCashierSet(address _newCashier, address _triggeredBy);
 
     modifier onlyOwner() {
         require(msg.sender == owner, "UNAUTHORIZED_O"); //hex"10" FISSION.code(FISSION.Category.Permission, FISSION.Status.Disallowed_Stop)
@@ -98,7 +97,7 @@ contract ERC1155ERC721 is IERC1155, IERC721, IERC1155ERC721 {
             "UNAUTHORIZED_ST"
         ); //hex"10"FISSION.code(FISSION.Category.Permission, FISSION.Status.Disallowed_Stop)
 
-        IBosonRouter(bosonRouterAddress)._beforeERC1155Transfer(
+        ICashier(cashierAddress).beforeERC1155Transfer(
             _from,
             _tokenId,
             _value
@@ -108,7 +107,7 @@ contract ERC1155ERC721 is IERC1155, IERC721, IERC1155ERC721 {
         balances[_tokenId][_from] = balances[_tokenId][_from].sub(_value);
         balances[_tokenId][_to] = _value.add(balances[_tokenId][_to]);
 
-        IBosonRouter(bosonRouterAddress)._onERC1155Transfer(
+        ICashier(cashierAddress).onERC1155Transfer(
             _from,
             _to,
             _tokenId,
@@ -227,7 +226,7 @@ contract ERC1155ERC721 is IERC1155, IERC721, IERC1155ERC721 {
 
         require(IVoucherKernel(voucherKernelAddress).isVoucherTransferable(_tokenId), "FUNDS_RELEASED");
 
-        IBosonRouter(bosonRouterAddress)._onERC721Transfer(
+        ICashier(cashierAddress).onERC721Transfer(
             _from,
             _to,
             _tokenId
@@ -309,7 +308,7 @@ contract ERC1155ERC721 is IERC1155, IERC721, IERC1155ERC721 {
             uint256 tokenId = _tokenIds[i];
             uint256 value = _values[i];
 
-            IBosonRouter(bosonRouterAddress)._beforeERC1155Transfer(
+            ICashier(cashierAddress).beforeERC1155Transfer(
                 _from,
                 tokenId,
                 value
@@ -319,7 +318,7 @@ contract ERC1155ERC721 is IERC1155, IERC721, IERC1155ERC721 {
             balances[tokenId][_from] = balances[tokenId][_from].sub(value);
             balances[tokenId][_to] = value.add(balances[tokenId][_to]);
 
-            IBosonRouter(bosonRouterAddress)._onERC1155Transfer(
+            ICashier(cashierAddress).onERC1155Transfer(
                 _from,
                 _to,
                 tokenId,
@@ -830,16 +829,16 @@ contract ERC1155ERC721 is IERC1155, IERC721, IERC1155ERC721 {
     }
 
     /**
-     * @notice Set the address of the Boson Router contract
-     * @param _bosonRouterAddress   The Boson Router  contract
+     * @notice Set the address of the cashier contract
+     * @param _cashierAddress   The Boson Router  contract
      */
-    function setBosonRouterAddress(address _bosonRouterAddress)
+    function setCashierAddress(address _cashierAddress)
         external
         onlyOwner
-        notZeroAddress(_bosonRouterAddress)
+        notZeroAddress(_cashierAddress)
     {
-        bosonRouterAddress = _bosonRouterAddress;
-        emit LogBosonRouterSet(_bosonRouterAddress, msg.sender);
+        cashierAddress = _cashierAddress;
+        emit LogCashierSet(_cashierAddress, msg.sender);
     }
 
     /**

--- a/contracts/VoucherKernel.sol
+++ b/contracts/VoucherKernel.sol
@@ -875,7 +875,7 @@ contract VoucherKernel is IVoucherKernel, Ownable, Pausable, UsingHelpers {
     function setSupplyHolderOnTransfer(
         uint256 _tokenIdSupply,
         address _newSeller
-    ) external override onlyFromRouter {
+    ) external override onlyFromCashier {
         bytes32 promiseKey = ordersPromise[_tokenIdSupply];
         promises[promiseKey].seller = _newSeller;
     }

--- a/contracts/interfaces/IBosonRouter.sol
+++ b/contracts/interfaces/IBosonRouter.sol
@@ -134,46 +134,8 @@ interface IBosonRouter {
     function cancelOrFault(uint256 _tokenIdVoucher) external;
 
     /**
-     * @notice Hook which will be triggered when a _tokenIdVoucher will be transferred. Escrow funds should be allocated to the new owner.
-     * @param _from prev owner of the _tokenIdVoucher
-     * @param _to next owner of the _tokenIdVoucher
-     * @param _tokenIdVoucher _tokenIdVoucher that has been transferred
+     * @notice Increment a seller or buyer's correlation Id
+     * @param _party   The address of the seller or buyer
      */
-    function _onERC721Transfer(
-        address _from,
-        address _to,
-        uint256 _tokenIdVoucher
-    ) external;
-
-    /**
-     * @notice Pre-validation when a transfer from the the Tokens contract is triggered. Only the whole supply is allowed for transfer, otherwise reverts.
-     * @param _from owner of the _tokenSupplyId
-     * @param _tokenSupplyId _tokenSupplyId which will be validated
-     * @param _value qty which is desired to be transferred
-     */
-    function _beforeERC1155Transfer(
-        address _from,
-        uint256 _tokenSupplyId,
-        uint256 _value
-    ) external view;
-
-    /**
-     * @notice After the transfer happens the _tokenSupplyId should be updated in the promise. Escrow funds for the deposits (If in ETH) should be allocated to the new owner as well.
-     * @param _from prev owner of the _tokenSupplyId
-     * @param _to next owner of the _tokenSupplyId
-     * @param _tokenSupplyId _tokenSupplyId for transfer
-     * @param _value qty which has been transferred
-     */
-    function _onERC1155Transfer(
-        address _from,
-        address _to,
-        uint256 _tokenSupplyId,
-        uint256 _value
-    ) external;
-
-    /**
-     * @notice Set the address of the ERC1155ERC721 contract
-     * @param _tokensContractAddress   The address of the ERC1155ERC721 contract
-     */
-    function setTokenContractAddress(address _tokensContractAddress) external;
+    function incrementCorrelationId(address _party) external;
 }

--- a/contracts/interfaces/ICashier.sol
+++ b/contracts/interfaces/ICashier.sol
@@ -77,18 +77,6 @@ interface ICashier {
     ) external;
 
     /**
-     * @notice Pre-validation when a transfer from the the Tokens contract is triggered. Only the whole supply is allowed for transfer, otherwise reverts.
-     * @param _from owner of the _tokenSupplyId
-     * @param _tokenSupplyId _tokenSupplyId which will be validated
-     * @param _value qty which is desired to be transferred
-     */
-    function beforeERC1155Transfer(
-        address _from,
-        uint256 _tokenSupplyId,
-        uint256 _value
-    ) external view;
-
-    /**
      * @notice After the transfer happens the _tokenSupplyId should be updated in the promise. Escrow funds for the deposits (If in ETH) should be allocated to the new owner as well.
      * @param _from prev owner of the _tokenSupplyId
      * @param _to next owner of the _tokenSupplyId

--- a/contracts/interfaces/ICashier.sol
+++ b/contracts/interfaces/ICashier.sol
@@ -49,27 +49,8 @@ interface ICashier {
     /**
      * @notice Update the amount in escrow of an address with the new value, based on VoucherSet/Voucher interaction
      * @param _account  The address of an account to query
-     * @param _newAmount  New amount to be set
-     */
-    function updateEscrowAmount(address _account, uint256 _newAmount) external;
-
-    /**
-     * @notice Update the amount in escrow of an address with the new value, based on VoucherSet/Voucher interaction
-     * @param _account  The address of an account to query
      */
     function addEscrowAmount(address _account) external payable;
-
-    /**
-     * @notice Update the amount in escrowTokens of an address with the new value, based on VoucherSet/Voucher interaction
-     * @param _token  The address of a token to query
-     * @param _account  The address of an account to query
-     * @param _newAmount  New amount to be set
-     */
-    function updateEscrowTokensAmount(
-        address _token,
-        address _account,
-        uint256 _newAmount
-    ) external;
 
     /**
      * @notice Update the amount in escrowTokens of an address with the new value, based on VoucherSet/Voucher interaction
@@ -81,6 +62,44 @@ interface ICashier {
         address _token,
         address _account,
         uint256 _newAmount
+    ) external;
+
+    /**
+     * @notice Hook which will be triggered when a _tokenIdVoucher will be transferred. Escrow funds should be allocated to the new owner.
+     * @param _from prev owner of the _tokenIdVoucher
+     * @param _to next owner of the _tokenIdVoucher
+     * @param _tokenIdVoucher _tokenIdVoucher that has been transferred
+     */
+    function onERC721Transfer(
+        address _from,
+        address _to,
+        uint256 _tokenIdVoucher
+    ) external;
+
+    /**
+     * @notice Pre-validation when a transfer from the the Tokens contract is triggered. Only the whole supply is allowed for transfer, otherwise reverts.
+     * @param _from owner of the _tokenSupplyId
+     * @param _tokenSupplyId _tokenSupplyId which will be validated
+     * @param _value qty which is desired to be transferred
+     */
+    function beforeERC1155Transfer(
+        address _from,
+        uint256 _tokenSupplyId,
+        uint256 _value
+    ) external view;
+
+    /**
+     * @notice After the transfer happens the _tokenSupplyId should be updated in the promise. Escrow funds for the deposits (If in ETH) should be allocated to the new owner as well.
+     * @param _from prev owner of the _tokenSupplyId
+     * @param _to next owner of the _tokenSupplyId
+     * @param _tokenSupplyId _tokenSupplyId for transfer
+     * @param _value qty which has been transferred
+     */
+    function onERC1155Transfer(
+        address _from,
+        address _to,
+        uint256 _tokenSupplyId,
+        uint256 _value
     ) external;
 
     /**
@@ -99,4 +118,10 @@ interface ICashier {
      * @param _bosonRouterAddress   The address of the Cashier contract
      */
     function setBosonRouterAddress(address _bosonRouterAddress) external;
+
+    /**
+     * @notice Set the address of the ERC1155ERC721 contract
+     * @param _tokensContractAddress   The address of the ERC1155ERC721 contract
+     */
+    function setTokenContractAddress(address _tokensContractAddress) external;
 }

--- a/migrations/1_deploy_contracts.js
+++ b/migrations/1_deploy_contracts.js
@@ -15,20 +15,22 @@ module.exports = function(deployer, network, accounts) {
         return deployer.deploy(ERC1155ERC721).then(function() {
             return deployer.deploy(VoucherKernel, ERC1155ERC721.address).then(function() {
                 return deployer.deploy(Cashier, VoucherKernel.address).then(function() {
-                    return deployer.deploy(BosonRouter, VoucherKernel.address, ERC1155ERC721.address, FundLimitsOracle.address, Cashier.address).then(async function() {
+                    return deployer.deploy(BosonRouter, VoucherKernel.address, FundLimitsOracle.address, Cashier.address).then(async function() {
 
                         console.log("$ Setting initial values ...");
                         await ERC1155ERC721.deployed().then(async(instance) => {
                             await instance.setApprovalForAll(VoucherKernel.address, 'true').then(tx =>
                                 console.log("\n$ ERC1155ERC721", tx.logs[0].event, "approved VoucherKernel:", tx.logs[0].args._approved))
                         });
+                        
                         await ERC1155ERC721.deployed().then(async(instance) => {
                             await instance.setVoucherKernelAddress(VoucherKernel.address).then(tx =>
                                 console.log("\n$ ERC1155ERC721", tx.logs[0].event, "at:", tx.logs[0].args._newVoucherKernel))
                         });
+
                         await ERC1155ERC721.deployed().then(async(instance) => {
-                            await instance.setBosonRouterAddress(BosonRouter.address).then(tx =>
-                                console.log("\n$ ERC1155ERC721", tx.logs[0].event, "at:", tx.logs[0].args._newBosonRouter))
+                            await instance.setCashierAddress(Cashier.address).then(tx =>
+                                console.log("\n$ ERC1155ERC721", tx.logs[0].event, "at:", tx.logs[0].args._newCashier))
                         });
 
                         await VoucherKernel.deployed().then(async(instance) => {
@@ -43,7 +45,12 @@ module.exports = function(deployer, network, accounts) {
 
                         await Cashier.deployed().then(async(instance) => {
                             await instance.setBosonRouterAddress(BosonRouter.address).then(tx =>
-                                console.log("\n$ VoucherKernel", tx.logs[0].event, "at:", tx.logs[0].args._newBosonRouter))
+                                console.log("\n$ Cashier", tx.logs[0].event, "at:", tx.logs[0].args._newBosonRouter))
+                        });
+
+                        await Cashier.deployed().then(async(instance) => {
+                            await instance.setTokenContractAddress(ERC1155ERC721.address).then(tx =>
+                                console.log("\n$ Cashier", tx.logs[0].event, "at:", tx.logs[0].args._newTokenContract))
                         });
 
                         console.log("FundLimitsOracle Contract Address: ", FundLimitsOracle.address);

--- a/test/1_test_fullpath.js
+++ b/test/1_test_fullpath.js
@@ -56,8 +56,6 @@ contract('Voucher tests', async (addresses) => {
 
     await contractERC1155ERC721.setCashierAddress(contractCashier.address);
 
-    await contractERC1155ERC721.setCashierAddress(contractCashier.address);
-
     await contractVoucherKernel.setBosonRouterAddress(
       contractBosonRouter.address
     );
@@ -1151,8 +1149,6 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
     await contractERC1155ERC721.setVoucherKernelAddress(
       contractVoucherKernel.address
     );
-
-    await contractERC1155ERC721.setCashierAddress(contractCashier.address);
 
     await contractERC1155ERC721.setCashierAddress(contractCashier.address);
 

--- a/test/1_test_fullpath.js
+++ b/test/1_test_fullpath.js
@@ -6,14 +6,14 @@ const constants = require('../testHelpers/constants');
 const timemachine = require('../testHelpers/timemachine');
 const Utils = require('../testHelpers/utils');
 const Users = require('../testHelpers/users');
+const {assert} = require('chai');
 
 const ERC1155ERC721 = artifacts.require('ERC1155ERC721');
 const VoucherKernel = artifacts.require('VoucherKernel');
 const Cashier = artifacts.require('Cashier');
 const BosonRouter = artifacts.require('BosonRouter');
 const FundLimitsOracle = artifacts.require('FundLimitsOracle');
-
-let snapshot;
+const BN = web3.utils.BN;
 
 contract('Voucher tests', async (addresses) => {
   const users = new Users(addresses);
@@ -23,12 +23,15 @@ contract('Voucher tests', async (addresses) => {
     contractCashier,
     contractBosonRouter,
     contractFundLimitsOracle;
-  let tokenSupplyKey1, tokenSupplyKey2, tokenVoucherKey1, tokenVoucherKey2;
+  let tokenSupplyKey1,
+    tokenSupplyKey2,
+    tokenVoucherKey1,
+    tokenVoucherKey2,
+    promiseId1,
+    promiseId2;
 
-  before('setup contracts for tests', async () => {
+  beforeEach('setup contracts for tests', async () => {
     const sixtySeconds = 60;
-
-    snapshot = await timemachine.takeSnapshot();
 
     const timestamp = await Utils.getCurrTimestamp();
     constants.PROMISE_VALID_FROM = timestamp;
@@ -67,11 +70,6 @@ contract('Voucher tests', async (addresses) => {
 
     await contractVoucherKernel.setComplainPeriod(sixtySeconds);
     await contractVoucherKernel.setCancelFaultPeriod(sixtySeconds);
-
-    console.log('Seller:   ' + users.seller.address);
-    console.log('Buyer:    ' + users.buyer.address);
-    console.log('Attacker: ' + users.attacker.address);
-    console.log();
   });
 
   describe('Direct minting', function () {
@@ -90,7 +88,7 @@ contract('Voucher tests', async (addresses) => {
     });
   });
 
-  describe('Voucher Sets (ERC1155)', () => {
+  describe('Create Voucher Sets (ERC1155)', () => {
     it('adding one new order / promise', async () => {
       const txOrder = await contractBosonRouter.requestCreateOrderETHETH(
         [
@@ -108,19 +106,149 @@ contract('Voucher tests', async (addresses) => {
         }
       );
 
+      let tokenSupplyKey1;
+
       truffleAssert.eventEmitted(
         txOrder,
         'LogOrderCreated',
         (ev) => {
           tokenSupplyKey1 = ev._tokenIdSupply;
-          return ev._seller === users.seller.address;
+          return (
+            ev._tokenIdSupply.gt(constants.ZERO) &&
+            ev._seller === users.seller.address &&
+            ev._quantity.eq(new BN(constants.ORDER_QUANTITY1)) &&
+            ev._paymentType.eq(constants.ONE) &&
+            ev._correlationId.eq(constants.ZERO)
+          );
         },
-        'order1 not created successfully'
+        'order1 event incorrect'
       );
+
+      const internalVoucherKernelTx = await truffleAssert.createTransactionResult(
+        contractVoucherKernel,
+        txOrder.tx
+      );
+
+      let promiseId1;
+
+      truffleAssert.eventEmitted(
+        internalVoucherKernelTx,
+        'LogPromiseCreated',
+        (ev) => {
+          promiseId1 = ev._promiseId;
+          return (
+            ev._promiseId > 0 &&
+            ev._nonce.eq(constants.ONE) &&
+            ev._seller === users.seller.address &&
+            ev._validFrom.eq(new BN(constants.PROMISE_VALID_FROM)) &&
+            ev._validTo.eq(new BN(constants.PROMISE_VALID_TO)) &&
+            ev._idx.eq(constants.ZERO)
+          );
+        },
+        'promise event incorrect'
+      );
+
+      const internalTokenTx = await truffleAssert.createTransactionResult(
+        contractERC1155ERC721,
+        txOrder.tx
+      );
+
+      truffleAssert.eventEmitted(
+        internalTokenTx,
+        'TransferSingle',
+        (ev) => {
+          return (
+            ev._operator === contractVoucherKernel.address &&
+            ev._from === constants.ZERO_ADDRESS &&
+            ev._to == users.seller.address &&
+            ev._id.eq(tokenSupplyKey1) &&
+            ev._value.eq(new BN(constants.ORDER_QUANTITY1))
+          );
+        },
+        'transfer event incorrect'
+      );
+
+      //Check BosonRouter state
+      assert.equal(
+        await contractBosonRouter.correlationIds(users.seller.address),
+        1,
+        'Correlation Id incorrect'
+      );
+
+      //Check VocherKernel State
+      const promise = await contractVoucherKernel.promises(promiseId1);
+      assert.equal(promise.promiseId, promiseId1, 'Promise Id incorrect');
+      assert.isTrue(promise.nonce.eq(constants.ONE), 'Nonce is incorrect');
+      assert.strictEqual(
+        promise.seller,
+        users.seller.address,
+        'Seller incorrect'
+      );
+      assert.isTrue(promise.validFrom.eq(new BN(constants.PROMISE_VALID_FROM)));
+      assert.isTrue(promise.validTo.eq(new BN(constants.PROMISE_VALID_TO)));
+      assert.isTrue(promise.price.eq(new BN(constants.PROMISE_PRICE1)));
+      assert.isTrue(promise.depositSe.eq(new BN(constants.PROMISE_DEPOSITSE1)));
+      assert.isTrue(promise.depositBu.eq(new BN(constants.PROMISE_DEPOSITBU1)));
+      assert.isTrue(promise.idx.eq(constants.ZERO));
+
+      const orderPromiseId = await contractVoucherKernel.ordersPromise(
+        tokenSupplyKey1
+      );
+      assert.strictEqual(
+        orderPromiseId,
+        promiseId1,
+        'Order Promise Id incorrect'
+      );
+
+      const tokenNonce = await contractVoucherKernel.tokenNonces(
+        users.seller.address
+      );
+      assert.isTrue(tokenNonce.eq(constants.ONE));
+
+      //Check ERC1155ERC721 state
+      const sellerERC1155ERC721Balance = await contractERC1155ERC721.balanceOf(
+        users.seller.address,
+        tokenSupplyKey1
+      );
+      assert.isTrue(sellerERC1155ERC721Balance.eq(constants.ONE));
     });
 
-    it('adding second order', async () => {
-      const txOrder = await contractBosonRouter.requestCreateOrderETHETH(
+    it('adding two new orders / promises', async () => {
+      //Create 1st order
+      const txOrder1 = await contractBosonRouter.requestCreateOrderETHETH(
+        [
+          constants.PROMISE_VALID_FROM,
+          constants.PROMISE_VALID_TO,
+          constants.PROMISE_PRICE1,
+          constants.PROMISE_DEPOSITSE1,
+          constants.PROMISE_DEPOSITBU1,
+          constants.ORDER_QUANTITY1,
+        ],
+        {
+          from: users.seller.address,
+          to: contractCashier.address,
+          value: constants.PROMISE_DEPOSITSE1,
+        }
+      );
+
+      truffleAssert.eventEmitted(
+        txOrder1,
+        'LogOrderCreated',
+        (ev) => {
+          tokenSupplyKey1 = ev._tokenIdSupply;
+          return (
+            ev._tokenIdSupply.gt(constants.ZERO) &&
+            ev._seller === users.seller.address &&
+            ev._quantity.eq(new BN(constants.ORDER_QUANTITY1)) &&
+            ev._paymentType.eq(constants.ONE) &&
+            ev._correlationId.eq(constants.ZERO)
+          );
+        },
+        'order1 event incorrect'
+      );
+
+      //Create 2nd order
+      const txOrder2 = await contractBosonRouter.requestCreateOrderETHETH(
         [
           constants.PROMISE_VALID_FROM,
           constants.PROMISE_VALID_TO,
@@ -137,17 +265,206 @@ contract('Voucher tests', async (addresses) => {
       );
 
       truffleAssert.eventEmitted(
-        txOrder,
+        txOrder2,
         'LogOrderCreated',
         (ev) => {
           tokenSupplyKey2 = ev._tokenIdSupply;
-          return ev._seller === users.seller.address;
+          return (
+            ev._tokenIdSupply.gt(constants.ZERO) &&
+            ev._seller === users.seller.address &&
+            ev._quantity.eq(new BN(constants.ORDER_QUANTITY2)) &&
+            ev._paymentType.eq(constants.ONE) &&
+            ev._correlationId.eq(constants.ONE)
+          );
         },
-        'order2 not created successfully'
+        'order2 event incorrect'
+      );
+
+      const internalVoucherKernelTx = await truffleAssert.createTransactionResult(
+        contractVoucherKernel,
+        txOrder2.tx
+      );
+
+      let promiseId2;
+
+      truffleAssert.eventEmitted(
+        internalVoucherKernelTx,
+        'LogPromiseCreated',
+        (ev) => {
+          promiseId2 = ev._promiseId;
+          return (
+            ev._promiseId > 0 &&
+            ev._nonce.eq(new BN(2)) &&
+            ev._seller === users.seller.address &&
+            ev._validFrom.eq(new BN(constants.PROMISE_VALID_FROM)) &&
+            ev._validTo.eq(new BN(constants.PROMISE_VALID_TO)) &&
+            ev._idx.eq(constants.ONE)
+          );
+        },
+        'promise event incorrect'
+      );
+
+      const internalTokenTx = await truffleAssert.createTransactionResult(
+        contractERC1155ERC721,
+        txOrder2.tx
+      );
+
+      truffleAssert.eventEmitted(
+        internalTokenTx,
+        'TransferSingle',
+        (ev) => {
+          return (
+            ev._operator === contractVoucherKernel.address &&
+            ev._from === constants.ZERO_ADDRESS &&
+            ev._to === users.seller.address &&
+            ev._id.eq(tokenSupplyKey2) &&
+            ev._value.eq(new BN(constants.ORDER_QUANTITY2))
+          );
+        },
+        'transfer event incorrect'
+      );
+
+      //Check BosonRouter state
+      assert.equal(
+        await contractBosonRouter.correlationIds(users.seller.address),
+        2,
+        'Correlation Id incorrect'
+      );
+
+      //Check VocherKernel State
+      const promise = await contractVoucherKernel.promises(promiseId2);
+      assert.strictEqual(promise.promiseId, promiseId2, 'Promise Id incorrect');
+      assert.isTrue(promise.nonce.eq(new BN(2)));
+      assert.strictEqual(
+        promise.seller,
+        users.seller.address,
+        'Seller incorrect'
+      );
+      assert.isTrue(promise.validFrom.eq(new BN(constants.PROMISE_VALID_FROM)));
+      assert.isTrue(promise.validTo.eq(new BN(constants.PROMISE_VALID_TO)));
+      assert.isTrue(promise.price.eq(new BN(constants.PROMISE_PRICE2)));
+      assert.isTrue(promise.depositSe.eq(new BN(constants.PROMISE_DEPOSITSE2)));
+      assert.isTrue(promise.depositBu.eq(new BN(constants.PROMISE_DEPOSITBU2)));
+      assert.isTrue(promise.idx.eq(constants.ONE));
+
+      const orderPromiseId = await contractVoucherKernel.ordersPromise(
+        tokenSupplyKey2
+      );
+      assert.strictEqual(
+        orderPromiseId,
+        promiseId2,
+        'Order Promise Id incorrect'
+      );
+
+      const tokenNonce = await contractVoucherKernel.tokenNonces(
+        users.seller.address
+      );
+      assert.isTrue(tokenNonce.eq(new BN(2)));
+
+      //Check ERC1155ERC721 state
+      const sellerERC1155ERC721BalanceVoucherSet1 = await contractERC1155ERC721.balanceOf(
+        users.seller.address,
+        tokenSupplyKey1
+      );
+      assert.isTrue(sellerERC1155ERC721BalanceVoucherSet1.eq(constants.ONE));
+
+      const sellerERC1155ERC721BalanceVoucherSet2 = await contractERC1155ERC721.balanceOf(
+        users.seller.address,
+        tokenSupplyKey2
+      );
+      assert.isTrue(sellerERC1155ERC721BalanceVoucherSet2.eq(constants.ONE));
+    });
+  });
+
+  describe('Commit to buy a voucher (ERC1155)', () => {
+    beforeEach('execute prerequisite steps', async () => {
+      //Create first voucher set
+      const txOrder = await contractBosonRouter.requestCreateOrderETHETH(
+        [
+          constants.PROMISE_VALID_FROM,
+          constants.PROMISE_VALID_TO,
+          constants.PROMISE_PRICE1,
+          constants.PROMISE_DEPOSITSE1,
+          constants.PROMISE_DEPOSITBU1,
+          constants.ORDER_QUANTITY1,
+        ],
+        {
+          from: users.seller.address,
+          to: contractBosonRouter.address,
+          value: constants.PROMISE_DEPOSITSE1,
+        }
+      );
+
+      truffleAssert.eventEmitted(
+        txOrder,
+        'LogOrderCreated',
+        (ev) => {
+          tokenSupplyKey1 = ev._tokenIdSupply;
+          return ev._tokenIdSupply.gt(constants.ZERO);
+        },
+        'order1 not created successfully'
+      );
+
+      const internalVoucherKernelTx = await truffleAssert.createTransactionResult(
+        contractVoucherKernel,
+        txOrder.tx
+      );
+
+      truffleAssert.eventEmitted(
+        internalVoucherKernelTx,
+        'LogPromiseCreated',
+        (ev) => {
+          promiseId1 = ev._promiseId;
+          return ev._promiseId > 0;
+        },
+        'promise event incorrect'
+      );
+
+      //Create 2nd voucher set
+      const txOrder2 = await contractBosonRouter.requestCreateOrderETHETH(
+        [
+          constants.PROMISE_VALID_FROM,
+          constants.PROMISE_VALID_TO,
+          constants.PROMISE_PRICE2,
+          constants.PROMISE_DEPOSITSE2,
+          constants.PROMISE_DEPOSITBU2,
+          constants.ORDER_QUANTITY2,
+        ],
+        {
+          from: users.seller.address,
+          to: contractCashier.address,
+          value: constants.PROMISE_DEPOSITSE2,
+        }
+      );
+
+      truffleAssert.eventEmitted(
+        txOrder2,
+        'LogOrderCreated',
+        (ev) => {
+          tokenSupplyKey2 = ev._tokenIdSupply;
+          return ev._tokenIdSupply.gt(constants.ZERO);
+        },
+        'order2 event incorrect'
+      );
+
+      const internalVoucherKernelTx2 = await truffleAssert.createTransactionResult(
+        contractVoucherKernel,
+        txOrder2.tx
+      );
+
+      truffleAssert.eventEmitted(
+        internalVoucherKernelTx2,
+        'LogPromiseCreated',
+        (ev) => {
+          promiseId2 = ev._promiseId;
+          return ev._promiseId > 0;
+        },
+        'promise event incorrect'
       );
     });
 
     it('fill one order (aka commit to buy a voucher)', async () => {
+      //Buyer commits
       const txFillOrder = await contractBosonRouter.requestVoucherETHETH(
         tokenSupplyKey1,
         users.seller.address,
@@ -162,20 +479,94 @@ contract('Voucher tests', async (addresses) => {
         txFillOrder.tx
       );
 
+      let tokenVoucherKey;
+
       truffleAssert.eventEmitted(
         internalTx,
         'LogVoucherDelivered',
         (ev) => {
-          return ev._issuer === users.seller.address;
+          tokenVoucherKey = ev._tokenIdVoucher;
+          return (
+            ev._tokenIdSupply.eq(tokenSupplyKey1) &&
+            ev._tokenIdVoucher.gt(constants.ZERO) &&
+            ev._issuer === users.seller.address &&
+            ev._holder === users.buyer.address &&
+            ev._promiseId === promiseId1 &&
+            ev._correlationId.eq(constants.ZERO)
+          );
         },
         'order1 not created successfully'
       );
 
-      const filtered = internalTx.logs.filter(
-        (e) => e.event === 'LogVoucherDelivered'
-      )[0];
+      const internalTokenTx = await truffleAssert.createTransactionResult(
+        contractERC1155ERC721,
+        txFillOrder.tx
+      );
 
-      tokenVoucherKey1 = filtered.returnValues['_tokenIdVoucher'];
+      truffleAssert.eventEmitted(
+        internalTokenTx,
+        'TransferSingle',
+        (ev) => {
+          return (
+            ev._operator === contractVoucherKernel.address &&
+            ev._from === users.seller.address &&
+            ev._to === constants.ZERO_ADDRESS &&
+            ev._id.eq(tokenSupplyKey1) &&
+            ev._value.eq(constants.ONE)
+          );
+        },
+        'transfer single event incorrect'
+      );
+
+      truffleAssert.eventEmitted(
+        internalTokenTx,
+        'Transfer',
+        (ev) => {
+          return (
+            ev._from === constants.ZERO_ADDRESS &&
+            ev._to === users.buyer.address &&
+            ev._tokenId.eq(tokenVoucherKey)
+          );
+        },
+        'transfer event incorrect'
+      );
+
+      //Check BosonRouter state
+      assert.equal(
+        await contractBosonRouter.correlationIds(users.buyer.address),
+        1,
+        'Correlation Id incorrect'
+      );
+
+      //Check Voucher Kernel state
+      const voucherStatus = await contractVoucherKernel.vouchersStatus(
+        tokenVoucherKey
+      );
+      assert.isTrue(voucherStatus.status.eq(new BN(128))); //128 = COMMITTED
+      assert.isFalse(
+        voucherStatus.isPaymentReleased,
+        'Payment released not false'
+      );
+      assert.isFalse(
+        voucherStatus.isDepositsReleased,
+        'Deposit released not false'
+      );
+
+      //Check ERC1155ERC721 state
+      const sellerERC1155ERC721Balance = await contractERC1155ERC721.balanceOf(
+        users.seller.address,
+        tokenSupplyKey1
+      );
+      assert.isTrue(sellerERC1155ERC721Balance.eq(constants.ZERO));
+
+      const buyerERC721Balance = await contractERC1155ERC721.balanceOf(
+        users.buyer.address
+      );
+      const erc721TokenOwner = await contractERC1155ERC721.ownerOf(
+        tokenVoucherKey
+      );
+      assert.isTrue(buyerERC721Balance.eq(constants.ONE));
+      assert.strictEqual(users.buyer.address, erc721TokenOwner);
     });
 
     it('fill second order (aka commit to buy a voucher)', async () => {
@@ -193,15 +584,94 @@ contract('Voucher tests', async (addresses) => {
         txFillOrder.tx
       );
 
+      let tokenVoucherKey;
+
       truffleAssert.eventEmitted(
         internalTx,
         'LogVoucherDelivered',
         (ev) => {
-          tokenVoucherKey2 = ev._tokenIdVoucher;
-          return ev._tokenIdSupply.toString() === tokenSupplyKey2.toString();
+          tokenVoucherKey = ev._tokenIdVoucher;
+          return (
+            ev._tokenIdSupply.eq(tokenSupplyKey2) &&
+            ev._tokenIdVoucher.gt(constants.ZERO) &&
+            ev._issuer === users.seller.address &&
+            ev._holder === users.buyer.address &&
+            ev._promiseId === promiseId2 &&
+            ev._correlationId.eq(constants.ZERO)
+          );
         },
-        'order1 not filled successfully'
+        'order2 not filled successfully'
       );
+
+      const internalTokenTx = await truffleAssert.createTransactionResult(
+        contractERC1155ERC721,
+        txFillOrder.tx
+      );
+
+      truffleAssert.eventEmitted(
+        internalTokenTx,
+        'TransferSingle',
+        (ev) => {
+          return (
+            ev._operator === contractVoucherKernel.address &&
+            ev._from === users.seller.address &&
+            ev._to === constants.ZERO_ADDRESS &&
+            ev._id.eq(tokenSupplyKey2) &&
+            ev._value.eq(constants.ONE)
+          );
+        },
+        'transfer single event incorrect'
+      );
+
+      truffleAssert.eventEmitted(
+        internalTokenTx,
+        'Transfer',
+        (ev) => {
+          return (
+            ev._from === constants.ZERO_ADDRESS &&
+            ev._to === users.buyer.address &&
+            ev._tokenId.eq(tokenVoucherKey)
+          );
+        },
+        'transfer event incorrect'
+      );
+
+      //Check BosonRouter state
+      assert.equal(
+        await contractBosonRouter.correlationIds(users.buyer.address),
+        1,
+        'Correlation Id incorrect'
+      );
+
+      //Check Voucher Kernel state
+      const voucherStatus = await contractVoucherKernel.vouchersStatus(
+        tokenVoucherKey
+      );
+      assert.isTrue(voucherStatus.status.eq(new BN(128))); //128 = COMMITTED
+      assert.isFalse(
+        voucherStatus.isPaymentReleased,
+        'Payment released not false'
+      );
+      assert.isFalse(
+        voucherStatus.isDepositsReleased,
+        'Deposit released not false'
+      );
+
+      //Check ERC1155ERC721 state
+      const sellerERC1155ERC721Balance = await contractERC1155ERC721.balanceOf(
+        users.seller.address,
+        tokenSupplyKey2
+      );
+      assert.isTrue(sellerERC1155ERC721Balance.eq(constants.ZERO));
+
+      const buyerERC721Balance = await contractERC1155ERC721.balanceOf(
+        users.buyer.address
+      );
+      const erc721TokenOwner = await contractERC1155ERC721.ownerOf(
+        tokenVoucherKey
+      );
+      assert.isTrue(buyerERC721Balance.eq(constants.ONE));
+      assert.strictEqual(users.buyer.address, erc721TokenOwner);
     });
 
     it('must fail: adding new order with incorrect value sent', async () => {
@@ -242,6 +712,128 @@ contract('Voucher tests', async (addresses) => {
   });
 
   describe('Vouchers (ERC721)', function () {
+    beforeEach('execute prerequisite steps', async () => {
+      //Create first voucher set
+      const txOrder = await contractBosonRouter.requestCreateOrderETHETH(
+        [
+          constants.PROMISE_VALID_FROM,
+          constants.PROMISE_VALID_TO,
+          constants.PROMISE_PRICE1,
+          constants.PROMISE_DEPOSITSE1,
+          constants.PROMISE_DEPOSITBU1,
+          constants.ORDER_QUANTITY1,
+        ],
+        {
+          from: users.seller.address,
+          to: contractBosonRouter.address,
+          value: constants.PROMISE_DEPOSITSE1,
+        }
+      );
+
+      truffleAssert.eventEmitted(
+        txOrder,
+        'LogOrderCreated',
+        (ev) => {
+          tokenSupplyKey1 = ev._tokenIdSupply;
+          return ev._tokenIdSupply.gt(constants.ZERO);
+        },
+        'order1 not created successfully'
+      );
+
+      const internalVoucherKernelTx = await truffleAssert.createTransactionResult(
+        contractVoucherKernel,
+        txOrder.tx
+      );
+
+      truffleAssert.eventEmitted(
+        internalVoucherKernelTx,
+        'LogPromiseCreated',
+        (ev) => {
+          promiseId1 = ev._promiseId;
+          return ev._promiseId > 0;
+        },
+        'promise event incorrect'
+      );
+
+      //Buyer commits - voucher set 1
+      const txFillOrder = await contractBosonRouter.requestVoucherETHETH(
+        tokenSupplyKey1,
+        users.seller.address,
+        {
+          from: users.buyer.address,
+          to: contractBosonRouter.address,
+          value: constants.PROMISE_PRICE1 + constants.PROMISE_DEPOSITBU1,
+        }
+      );
+
+      const internalTx = await truffleAssert.createTransactionResult(
+        contractVoucherKernel,
+        txFillOrder.tx
+      );
+
+      truffleAssert.eventEmitted(
+        internalTx,
+        'LogVoucherDelivered',
+        (ev) => {
+          tokenVoucherKey1 = ev._tokenIdVoucher;
+          return ev._tokenIdVoucher.gt(constants.ZERO);
+        },
+        'order1 not created successfully'
+      );
+
+      //Create 2nd voucher set
+      const txOrder2 = await contractBosonRouter.requestCreateOrderETHETH(
+        [
+          constants.PROMISE_VALID_FROM,
+          constants.PROMISE_VALID_TO,
+          constants.PROMISE_PRICE2,
+          constants.PROMISE_DEPOSITSE2,
+          constants.PROMISE_DEPOSITBU2,
+          constants.ORDER_QUANTITY2,
+        ],
+        {
+          from: users.seller.address,
+          to: contractCashier.address,
+          value: constants.PROMISE_DEPOSITSE2,
+        }
+      );
+
+      truffleAssert.eventEmitted(
+        txOrder2,
+        'LogOrderCreated',
+        (ev) => {
+          tokenSupplyKey2 = ev._tokenIdSupply;
+          return ev._tokenIdSupply.gt(constants.ZERO);
+        },
+        'order1 event incorrect'
+      );
+
+      //Buyer commits - Voucher Set 2
+      const txFillOrder2 = await contractBosonRouter.requestVoucherETHETH(
+        tokenSupplyKey2,
+        users.seller.address,
+        {
+          from: users.buyer.address,
+          to: contractBosonRouter.address,
+          value: constants.PROMISE_PRICE2 + constants.PROMISE_DEPOSITBU2,
+        }
+      );
+      const internalTx2 = await truffleAssert.createTransactionResult(
+        contractVoucherKernel,
+        txFillOrder2.tx
+      );
+
+      truffleAssert.eventEmitted(
+        internalTx2,
+        'LogVoucherDelivered',
+        (ev) => {
+          tokenVoucherKey2 = ev._tokenIdVoucher;
+          return ev._tokenIdVoucher.gt(constants.ZERO);
+        },
+        'order2 not filled successfully'
+      );
+    });
+
     it('redeeming one voucher', async () => {
       const txRedeem = await contractBosonRouter.redeem(tokenVoucherKey1, {
         from: users.buyer.address,
@@ -255,41 +847,79 @@ contract('Voucher tests', async (addresses) => {
         internalTx,
         'LogVoucherRedeemed',
         (ev) => {
-          return ev._tokenIdVoucher.toString() === tokenVoucherKey1.toString();
+          return (
+            ev._tokenIdVoucher.eq(tokenVoucherKey1) &&
+            ev._holder === users.buyer.address &&
+            ev._promiseId == promiseId1
+          );
         },
         'voucher not redeemed successfully'
+      );
+
+      //Check VoucherKernel state
+      const voucherStatus = await contractVoucherKernel.vouchersStatus(
+        tokenVoucherKey1
+      );
+      assert.isTrue(voucherStatus.status.eq(new BN(192)));
+
+      const transaction = await web3.eth.getTransaction(txRedeem.tx);
+      const transactionBlock = await web3.eth.getBlock(transaction.blockNumber);
+      assert.isTrue(
+        voucherStatus.complainPeriodStart.eq(new BN(transactionBlock.timestamp))
       );
     });
 
     it('mark non-redeemed voucher as expired', async () => {
-      const statusBefore = await contractVoucherKernel.getVoucherStatus.call(
+      const statusBefore = await contractVoucherKernel.vouchersStatus(
         tokenVoucherKey2
       );
 
       // [1000.0000] = hex"80" = 128 = COMMITTED
       assert.equal(
-        web3.utils.toHex(statusBefore[0]),
+        web3.utils.toHex(statusBefore.status),
         web3.utils.numberToHex(128),
         'initial voucher status not as expected (COMMITTED)'
       );
 
       // fast-forward for a year
       await timemachine.advanceTimeSeconds(constants.SECONDS_IN_DAY * 365);
-      await contractVoucherKernel.triggerExpiration(tokenVoucherKey2);
+      const expTx = await contractVoucherKernel.triggerExpiration(
+        tokenVoucherKey2
+      );
 
-      const statusAfter = await contractVoucherKernel.getVoucherStatus.call(
+      truffleAssert.eventEmitted(
+        expTx,
+        'LogExpirationTriggered',
+        (ev) => {
+          return (
+            ev._tokenIdVoucher.eq(tokenVoucherKey2) &&
+            ev._triggeredBy === users.deployer.address
+          );
+        },
+        'expiration not triggered successfully'
+      );
+
+      //Check VoucherKernel state
+      const voucherStatus = await contractVoucherKernel.vouchersStatus(
         tokenVoucherKey2
       );
 
       //[1001.0000] = hex"90" = 144 = EXPIRED
       assert.equal(
-        web3.utils.toHex(statusAfter[0]),
+        web3.utils.toHex(voucherStatus.status),
         web3.utils.numberToHex(144),
         'end voucher status not as expected (EXPIRED)'
       );
     });
 
     it('mark voucher as finalized', async () => {
+      await contractBosonRouter.redeem(tokenVoucherKey1, {
+        from: users.buyer.address,
+      });
+
+      //fast forward 8 days (complain period is 7)
+      await timemachine.advanceTimeSeconds(constants.SECONDS_IN_DAY * 8);
+
       const txFinalize = await contractVoucherKernel.triggerFinalizeVoucher(
         tokenVoucherKey1,
         {
@@ -301,10 +931,16 @@ contract('Voucher tests', async (addresses) => {
         txFinalize,
         'LogFinalizeVoucher',
         (ev) => {
-          return ev._tokenIdVoucher.toString() === tokenVoucherKey1.toString();
+          return ev._tokenIdVoucher.eq(tokenVoucherKey1);
         },
         'voucher not finalized successfully'
       );
+
+      //Check VoucherKernel state
+      const voucherStatus = await contractVoucherKernel.vouchersStatus(
+        tokenVoucherKey1
+      );
+      assert.isTrue(voucherStatus.status.eq(new BN(194)));
     });
 
     it('must fail: unauthorized redemption', async () => {
@@ -317,30 +953,164 @@ contract('Voucher tests', async (addresses) => {
     });
   });
 
+  //HS:  All other withdraw functions are tested in 3_withdrawals.js. Do we want to move this one?. Withdrawal of deposit not included here
   describe('Withdrawals', function () {
+    beforeEach('execute prerequisite steps', async () => {
+      //Create first voucher set
+      const txOrder = await contractBosonRouter.requestCreateOrderETHETH(
+        [
+          constants.PROMISE_VALID_FROM,
+          constants.PROMISE_VALID_TO,
+          constants.PROMISE_PRICE1,
+          constants.PROMISE_DEPOSITSE1,
+          constants.PROMISE_DEPOSITBU1,
+          constants.ORDER_QUANTITY1,
+        ],
+        {
+          from: users.seller.address,
+          to: contractBosonRouter.address,
+          value: constants.PROMISE_DEPOSITSE1,
+        }
+      );
+
+      truffleAssert.eventEmitted(
+        txOrder,
+        'LogOrderCreated',
+        (ev) => {
+          tokenSupplyKey1 = ev._tokenIdSupply;
+          return ev._tokenIdSupply.gt(constants.ZERO);
+        },
+        'order1 not created successfully'
+      );
+
+      const internalVoucherKernelTx = await truffleAssert.createTransactionResult(
+        contractVoucherKernel,
+        txOrder.tx
+      );
+
+      truffleAssert.eventEmitted(
+        internalVoucherKernelTx,
+        'LogPromiseCreated',
+        (ev) => {
+          promiseId1 = ev._promiseId;
+          return ev._promiseId > 0;
+        },
+        'promise event incorrect'
+      );
+
+      //Buyer commits - voucher set 1
+      const txFillOrder = await contractBosonRouter.requestVoucherETHETH(
+        tokenSupplyKey1,
+        users.seller.address,
+        {
+          from: users.buyer.address,
+          to: contractBosonRouter.address,
+          value: constants.PROMISE_PRICE1 + constants.PROMISE_DEPOSITBU1,
+        }
+      );
+
+      const internalTx = await truffleAssert.createTransactionResult(
+        contractVoucherKernel,
+        txFillOrder.tx
+      );
+
+      truffleAssert.eventEmitted(
+        internalTx,
+        'LogVoucherDelivered',
+        (ev) => {
+          tokenVoucherKey1 = ev._tokenIdVoucher;
+          return ev._tokenIdVoucher.gt(constants.ZERO);
+        },
+        'order1 not created successfully'
+      );
+
+      //Buyer redeems voucher
+      await contractBosonRouter.redeem(tokenVoucherKey1, {
+        from: users.buyer.address,
+      });
+    });
+
     it('withdraw the escrowed payment from one redeemed voucher', async () => {
-      const escrowedBefore = await contractCashier.getEscrowAmount.call(
+      const buyerEscrowedBefore = await contractCashier.getEscrowAmount.call(
         users.buyer.address
       );
 
-      await contractCashier.withdraw(tokenVoucherKey1);
+      const sellerBalanceBefore = await new BN(
+        await web3.eth.getBalance(users.seller.address)
+      );
 
-      const escrowedAfter = await contractCashier.getEscrowAmount.call(
+      const txWithdraw = await contractCashier.withdraw(tokenVoucherKey1, {
+        from: users.deployer.address,
+      });
+
+      truffleAssert.eventEmitted(
+        txWithdraw,
+        'LogAmountDistribution',
+        (ev) => {
+          return (
+            ev._tokenIdVoucher.eq(tokenVoucherKey1) &&
+            ev._to === users.seller.address &&
+            ev._payment.eq(new BN(constants.PROMISE_PRICE1)) &&
+            ev._type.eq(constants.ZERO)
+          );
+        },
+        'distribution unsuccessful'
+      );
+
+      const internalTx = await truffleAssert.createTransactionResult(
+        contractVoucherKernel,
+        txWithdraw.tx
+      );
+
+      truffleAssert.eventEmitted(
+        internalTx,
+        'LogFundsReleased',
+        (ev) => {
+          return (
+            ev._tokenIdVoucher.eq(tokenVoucherKey1) &&
+            ev._type.eq(constants.ZERO)
+          );
+        },
+        'funds not released successfully'
+      );
+
+      truffleAssert.eventEmitted(
+        txWithdraw,
+        'LogWithdrawal',
+        (ev) => {
+          return (
+            ev._caller === users.deployer.address &&
+            ev._payee === users.seller.address &&
+            ev._payment.eq(new BN(constants.PROMISE_PRICE1))
+          );
+        },
+        'withdrawal unsuccessful'
+      );
+
+      //Check Cashier state
+      const buyerEscrowedAfter = await contractCashier.getEscrowAmount.call(
         users.buyer.address
       );
 
-      assert.isBelow(
-        escrowedAfter.toNumber(),
-        escrowedBefore.toNumber(),
-        'escrowed amount not decreased'
+      buyerEscrowedAfter.gt(buyerEscrowedBefore);
+
+      //Check VoucherKernel state
+      const voucherStatus = await contractVoucherKernel.vouchersStatus(
+        tokenVoucherKey1
       );
+      assert.isTrue(voucherStatus.isPaymentReleased, 'Payment not released');
+
+      //Check seller account balance
+      const sellerBalanceAfter = new BN(
+        await web3.eth.getBalance(users.seller.address)
+      );
+      const expectedSellerBalance = sellerBalanceBefore.add(
+        new BN(constants.PROMISE_PRICE1)
+      );
+      assert.isTrue(sellerBalanceAfter.eq(expectedSellerBalance));
     });
   });
-
-  after(async () => {
-    await timemachine.revertToSnapShot(snapshot.id);
-  });
-});
+}); //end of contract
 
 contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
   const users = new Users(addresses);
@@ -352,11 +1122,7 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
     contractFundLimitsOracle;
   let tokenSupplyKey1, tokenVoucherKey1;
 
-  before('setup promise dates based on the block timestamp', async () => {
-    const sixtySeconds = 60;
-
-    snapshot = await timemachine.takeSnapshot();
-
+  beforeEach('setup promise dates based on the block timestamp', async () => {
     const timestamp = await Utils.getCurrTimestamp();
 
     constants.PROMISE_VALID_FROM = timestamp;
@@ -392,9 +1158,6 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
     await contractVoucherKernel.setCashierAddress(contractCashier.address);
 
     await contractCashier.setBosonRouterAddress(contractBosonRouter.address);
-
-    await contractVoucherKernel.setComplainPeriod(sixtySeconds);
-    await contractVoucherKernel.setCancelFaultPeriod(sixtySeconds);
   });
 
   beforeEach('setup contracts for tests', async () => {
@@ -455,7 +1218,10 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
         constants.PROMISE_CHALLENGE_PERIOD * constants.SECONDS_IN_DAY;
 
       const txChangePeriod = await contractVoucherKernel.setComplainPeriod(
-        complainPeriodSeconds
+        complainPeriodSeconds,
+        {
+          from: users.deployer.address,
+        }
       );
 
       truffleAssert.eventEmitted(
@@ -463,12 +1229,16 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
         'LogComplainPeriodChanged',
         (ev) => {
           return (
-            ev._newComplainPeriod.toString() ===
-            complainPeriodSeconds.toString()
+            ev._newComplainPeriod.eq(new BN(complainPeriodSeconds)) &&
+            ev._triggeredBy === users.deployer.address
           );
         },
         'complain period not changed successfully'
       );
+
+      //Check VoucherKernel state
+      const newComplainePeriod = await contractVoucherKernel.complainPeriod();
+      assert.isTrue(newComplainePeriod.eq(new BN(complainPeriodSeconds)));
     });
 
     it('must fail: unauthorized change of complain period', async () => {
@@ -487,7 +1257,10 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
       const cancelFaultPeriodSeconds =
         constants.PROMISE_CANCELORFAULT_PERIOD * constants.SECONDS_IN_DAY;
       const txChangePeriod = await contractVoucherKernel.setCancelFaultPeriod(
-        cancelFaultPeriodSeconds
+        cancelFaultPeriodSeconds,
+        {
+          from: users.deployer.address,
+        }
       );
 
       await truffleAssert.eventEmitted(
@@ -495,11 +1268,17 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
         'LogCancelFaultPeriodChanged',
         (ev) => {
           return (
-            ev._newCancelFaultPeriod.toString() ===
-            cancelFaultPeriodSeconds.toString()
+            ev._newCancelFaultPeriod.eq(new BN(cancelFaultPeriodSeconds)) &&
+            ev._triggeredBy === users.deployer.address
           );
         },
         'complain period not changed successfully'
+      );
+
+      //Check VoucherKernel state
+      const newCancelOrFaultPeriod = await contractVoucherKernel.cancelFaultPeriod();
+      assert.isTrue(
+        newCancelOrFaultPeriod.eq(new BN(cancelFaultPeriodSeconds))
       );
     });
 
@@ -517,17 +1296,37 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
 
   describe('Refunds ...', function () {
     it('refunding one voucher', async () => {
-      await contractBosonRouter.refund(tokenVoucherKey1, {
+      const txRefund = await contractBosonRouter.refund(tokenVoucherKey1, {
         from: users.buyer.address,
       });
 
-      const statusAfter = await contractVoucherKernel.getVoucherStatus.call(
+      const internalTx = await truffleAssert.createTransactionResult(
+        contractVoucherKernel,
+        txRefund.tx
+      );
+
+      await truffleAssert.eventEmitted(
+        internalTx,
+        'LogVoucherRefunded',
+        (ev) => {
+          return ev._tokenIdVoucher.eq(new BN(tokenVoucherKey1));
+        },
+        'refund not successful'
+      );
+
+      //Check VoucherKernel state
+      const voucherStatus = await contractVoucherKernel.vouchersStatus(
         tokenVoucherKey1
+      );
+      const transaction = await web3.eth.getTransaction(txRefund.tx);
+      const transactionBlock = await web3.eth.getBlock(transaction.blockNumber);
+      assert.isTrue(
+        voucherStatus.complainPeriodStart.eq(new BN(transactionBlock.timestamp))
       );
 
       // [1010.0000] = hex"A0" = 160 = REFUND
       assert.equal(
-        web3.utils.toHex(statusAfter[0]),
+        web3.utils.toHex(voucherStatus.status),
         web3.utils.numberToHex(160),
         'end voucher status not as expected (REFUNDED)'
       );
@@ -537,17 +1336,39 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
       await contractBosonRouter.refund(tokenVoucherKey1, {
         from: users.buyer.address,
       });
-      await contractBosonRouter.complain(tokenVoucherKey1, {
+      const complainTx = await contractBosonRouter.complain(tokenVoucherKey1, {
         from: users.buyer.address,
       });
 
-      const statusAfter = await contractVoucherKernel.getVoucherStatus.call(
+      const internalTx = await truffleAssert.createTransactionResult(
+        contractVoucherKernel,
+        complainTx.tx
+      );
+
+      await truffleAssert.eventEmitted(
+        internalTx,
+        'LogVoucherComplain',
+        (ev) => {
+          return ev._tokenIdVoucher.eq(new BN(tokenVoucherKey1));
+        },
+        'complain not successful'
+      );
+
+      //Check VoucherKernel state
+      const voucherStatus = await contractVoucherKernel.vouchersStatus(
         tokenVoucherKey1
+      );
+      const transaction = await web3.eth.getTransaction(complainTx.tx);
+      const transactionBlock = await web3.eth.getBlock(transaction.blockNumber);
+      assert.isTrue(
+        voucherStatus.cancelFaultPeriodStart.eq(
+          new BN(transactionBlock.timestamp)
+        )
       );
 
       // [1010.1000] = hex"A8" = 168 = REFUND_COMPLAIN
       assert.equal(
-        web3.utils.toHex(statusAfter[0]),
+        web3.utils.toHex(voucherStatus.status),
         web3.utils.numberToHex(168),
         'end voucher status not as expected (REFUNDED_COMPLAINED)'
       );
@@ -557,20 +1378,58 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
       await contractBosonRouter.refund(tokenVoucherKey1, {
         from: users.buyer.address,
       });
-      await contractBosonRouter.complain(tokenVoucherKey1, {
+      const complainTx = await contractBosonRouter.complain(tokenVoucherKey1, {
         from: users.buyer.address,
       });
-      await contractBosonRouter.cancelOrFault(tokenVoucherKey1, {
-        from: users.seller.address,
-      });
 
-      const statusAfter = await contractVoucherKernel.getVoucherStatus.call(
+      //Check VoucherKernel state
+      const voucherStatusBefore = await contractVoucherKernel.vouchersStatus(
         tokenVoucherKey1
+      );
+      const transaction = await web3.eth.getTransaction(complainTx.tx);
+      const transactionBlock = await web3.eth.getBlock(transaction.blockNumber);
+      assert.isTrue(
+        voucherStatusBefore.cancelFaultPeriodStart.eq(
+          new BN(transactionBlock.timestamp)
+        )
+      );
+
+      const cancelTx = await contractBosonRouter.cancelOrFault(
+        tokenVoucherKey1,
+        {
+          from: users.seller.address,
+        }
+      );
+
+      const internalTx = await truffleAssert.createTransactionResult(
+        contractVoucherKernel,
+        cancelTx.tx
+      );
+
+      await truffleAssert.eventEmitted(
+        internalTx,
+        'LogVoucherFaultCancel',
+        (ev) => {
+          return ev._tokenIdVoucher.eq(new BN(tokenVoucherKey1));
+        },
+        'complain not successful'
+      );
+
+      //Check VoucherKernel state
+      const voucherStatusAfter = await contractVoucherKernel.vouchersStatus(
+        tokenVoucherKey1
+      );
+
+      //Check it didn't go into a branch that changes the complainPeriodStart
+      assert.isTrue(
+        voucherStatusAfter.complainPeriodStart.eq(
+          new BN(transactionBlock.timestamp)
+        )
       );
 
       // [1010.1100] = hex"AC" = 172 = REFUND_COMPLAIN_COF
       assert.equal(
-        web3.utils.toHex(statusAfter[0]),
+        web3.utils.toHex(voucherStatusAfter.status),
         web3.utils.numberToHex(172),
         'end voucher status not as expected ' +
           '(REFUNDED_COMPLAINED_CANCELORFAULT)'
@@ -597,13 +1456,13 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
         from: users.seller.address,
       });
 
-      const statusAfter = await contractVoucherKernel.getVoucherStatus.call(
+      const voucherStatus = await contractVoucherKernel.vouchersStatus(
         tokenVoucherKey1
       );
 
       // [1000.0100] = hex"84" = 132 = CANCELORFAULT
       assert.equal(
-        web3.utils.toHex(statusAfter[0]),
+        web3.utils.toHex(voucherStatus.status),
         web3.utils.numberToHex(132),
         'end voucher status not as expected (CANCELORFAULT)'
       );
@@ -631,22 +1490,35 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
 
       await contractVoucherKernel.triggerExpiration(tokenVoucherKey1);
 
-      let statusAfter = await contractVoucherKernel.getVoucherStatus.call(
+      let statusAfter = await contractVoucherKernel.vouchersStatus(
         tokenVoucherKey1
       );
 
       // [1001.0000] = hex"90" = 144 = EXPIRED
       assert.equal(
-        web3.utils.toHex(statusAfter[0]),
+        web3.utils.toHex(statusAfter.status),
         web3.utils.numberToHex(144),
         'end voucher status not as expected (EXPIRED)'
       );
-
-      await contractBosonRouter.complain(tokenVoucherKey1, {
+      const complainTx = await contractBosonRouter.complain(tokenVoucherKey1, {
         from: users.buyer.address,
       });
 
-      statusAfter = await contractVoucherKernel.getVoucherStatus.call(
+      const internalTx = await truffleAssert.createTransactionResult(
+        contractVoucherKernel,
+        complainTx.tx
+      );
+
+      await truffleAssert.eventEmitted(
+        internalTx,
+        'LogVoucherComplain',
+        (ev) => {
+          return ev._tokenIdVoucher.eq(new BN(tokenVoucherKey1));
+        },
+        'complain not successful'
+      );
+
+      statusAfter = await contractVoucherKernel.vouchersStatus(
         tokenVoucherKey1
       );
 
@@ -658,11 +1530,28 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
       );
 
       // in the same test, because the EVM time machine is funky ...
-      await contractBosonRouter.cancelOrFault(tokenVoucherKey1, {
-        from: users.seller.address,
-      });
+      const cancelTx = await contractBosonRouter.cancelOrFault(
+        tokenVoucherKey1,
+        {
+          from: users.seller.address,
+        }
+      );
 
-      statusAfter = await contractVoucherKernel.getVoucherStatus.call(
+      const internalTx2 = await truffleAssert.createTransactionResult(
+        contractVoucherKernel,
+        cancelTx.tx
+      );
+
+      await truffleAssert.eventEmitted(
+        internalTx2,
+        'LogVoucherFaultCancel',
+        (ev) => {
+          return ev._tokenIdVoucher.eq(new BN(tokenVoucherKey1));
+        },
+        'complain not successful'
+      );
+
+      statusAfter = await contractVoucherKernel.vouchersStatus(
         tokenVoucherKey1
       );
 
@@ -681,10 +1570,6 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
         }),
         truffleAssert.ErrorType.REVERT
       );
-    });
-
-    after(async () => {
-      await timemachine.revertToSnapShot(snapshot.id);
     });
   });
 });

--- a/test/1_test_fullpath.js
+++ b/test/1_test_fullpath.js
@@ -18,6 +18,7 @@ const BN = web3.utils.BN;
 contract('Voucher tests', async (addresses) => {
   const users = new Users(addresses);
 
+
   let contractERC1155ERC721,
     contractVoucherKernel,
     contractCashier,
@@ -30,22 +31,18 @@ contract('Voucher tests', async (addresses) => {
     promiseId1,
     promiseId2;
 
-  beforeEach('setup contracts for tests', async () => {
+  async function deployContracts() {
     const sixtySeconds = 60;
-
-    const timestamp = await Utils.getCurrTimestamp();
-    constants.PROMISE_VALID_FROM = timestamp;
-    constants.PROMISE_VALID_TO = timestamp + 2 * constants.SECONDS_IN_DAY;
 
     contractFundLimitsOracle = await FundLimitsOracle.new();
     contractERC1155ERC721 = await ERC1155ERC721.new();
     contractVoucherKernel = await VoucherKernel.new(
       contractERC1155ERC721.address
     );
+
     contractCashier = await Cashier.new(contractVoucherKernel.address);
     contractBosonRouter = await BosonRouter.new(
       contractVoucherKernel.address,
-      contractERC1155ERC721.address,
       contractFundLimitsOracle.address,
       contractCashier.address
     );
@@ -57,8 +54,13 @@ contract('Voucher tests', async (addresses) => {
     await contractERC1155ERC721.setVoucherKernelAddress(
       contractVoucherKernel.address
     );
-    await contractERC1155ERC721.setBosonRouterAddress(
-      contractBosonRouter.address
+
+    await contractERC1155ERC721.setCashierAddress(
+      contractCashier.address
+    );
+
+    await contractERC1155ERC721.setCashierAddress(
+      contractCashier.address
     );
 
     await contractVoucherKernel.setBosonRouterAddress(
@@ -67,9 +69,20 @@ contract('Voucher tests', async (addresses) => {
     await contractVoucherKernel.setCashierAddress(contractCashier.address);
 
     await contractCashier.setBosonRouterAddress(contractBosonRouter.address);
+    await contractCashier.setTokenContractAddress(contractERC1155ERC721.address);
 
     await contractVoucherKernel.setComplainPeriod(sixtySeconds);
     await contractVoucherKernel.setCancelFaultPeriod(sixtySeconds);
+
+  }
+
+  beforeEach('setup contracts for tests', async () => {
+    const timestamp = await Utils.getCurrTimestamp();
+    constants.PROMISE_VALID_FROM = timestamp;
+    constants.PROMISE_VALID_TO = timestamp + 2 * constants.SECONDS_IN_DAY;
+
+    await deployContracts();
+
   });
 
   describe('Direct minting', function () {
@@ -1122,21 +1135,16 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
     contractFundLimitsOracle;
   let tokenSupplyKey1, tokenVoucherKey1;
 
-  beforeEach('setup promise dates based on the block timestamp', async () => {
-    const timestamp = await Utils.getCurrTimestamp();
-
-    constants.PROMISE_VALID_FROM = timestamp;
-    constants.PROMISE_VALID_TO = timestamp + 2 * constants.SECONDS_IN_DAY;
-
+  async function deployContracts() {
     contractFundLimitsOracle = await FundLimitsOracle.new();
     contractERC1155ERC721 = await ERC1155ERC721.new();
     contractVoucherKernel = await VoucherKernel.new(
       contractERC1155ERC721.address
     );
+
     contractCashier = await Cashier.new(contractVoucherKernel.address);
     contractBosonRouter = await BosonRouter.new(
       contractVoucherKernel.address,
-      contractERC1155ERC721.address,
       contractFundLimitsOracle.address,
       contractCashier.address
     );
@@ -1148,8 +1156,13 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
     await contractERC1155ERC721.setVoucherKernelAddress(
       contractVoucherKernel.address
     );
-    await contractERC1155ERC721.setBosonRouterAddress(
-      contractBosonRouter.address
+
+    await contractERC1155ERC721.setCashierAddress(
+      contractCashier.address
+    );
+
+    await contractERC1155ERC721.setCashierAddress(
+      contractCashier.address
     );
 
     await contractVoucherKernel.setBosonRouterAddress(
@@ -1158,6 +1171,17 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
     await contractVoucherKernel.setCashierAddress(contractCashier.address);
 
     await contractCashier.setBosonRouterAddress(contractBosonRouter.address);
+    await contractCashier.setTokenContractAddress(contractERC1155ERC721.address);
+
+  }
+
+  beforeEach('setup promise dates based on the block timestamp', async () => {
+    const timestamp = await Utils.getCurrTimestamp();
+
+    constants.PROMISE_VALID_FROM = timestamp;
+    constants.PROMISE_VALID_TO = timestamp + 2 * constants.SECONDS_IN_DAY;
+
+    await deployContracts();
   });
 
   beforeEach('setup contracts for tests', async () => {

--- a/test/1_test_fullpath.js
+++ b/test/1_test_fullpath.js
@@ -18,7 +18,6 @@ const BN = web3.utils.BN;
 contract('Voucher tests', async (addresses) => {
   const users = new Users(addresses);
 
-
   let contractERC1155ERC721,
     contractVoucherKernel,
     contractCashier,
@@ -55,13 +54,9 @@ contract('Voucher tests', async (addresses) => {
       contractVoucherKernel.address
     );
 
-    await contractERC1155ERC721.setCashierAddress(
-      contractCashier.address
-    );
+    await contractERC1155ERC721.setCashierAddress(contractCashier.address);
 
-    await contractERC1155ERC721.setCashierAddress(
-      contractCashier.address
-    );
+    await contractERC1155ERC721.setCashierAddress(contractCashier.address);
 
     await contractVoucherKernel.setBosonRouterAddress(
       contractBosonRouter.address
@@ -69,11 +64,12 @@ contract('Voucher tests', async (addresses) => {
     await contractVoucherKernel.setCashierAddress(contractCashier.address);
 
     await contractCashier.setBosonRouterAddress(contractBosonRouter.address);
-    await contractCashier.setTokenContractAddress(contractERC1155ERC721.address);
+    await contractCashier.setTokenContractAddress(
+      contractERC1155ERC721.address
+    );
 
     await contractVoucherKernel.setComplainPeriod(sixtySeconds);
     await contractVoucherKernel.setCancelFaultPeriod(sixtySeconds);
-
   }
 
   beforeEach('setup contracts for tests', async () => {
@@ -82,7 +78,6 @@ contract('Voucher tests', async (addresses) => {
     constants.PROMISE_VALID_TO = timestamp + 2 * constants.SECONDS_IN_DAY;
 
     await deployContracts();
-
   });
 
   describe('Direct minting', function () {
@@ -1157,13 +1152,9 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
       contractVoucherKernel.address
     );
 
-    await contractERC1155ERC721.setCashierAddress(
-      contractCashier.address
-    );
+    await contractERC1155ERC721.setCashierAddress(contractCashier.address);
 
-    await contractERC1155ERC721.setCashierAddress(
-      contractCashier.address
-    );
+    await contractERC1155ERC721.setCashierAddress(contractCashier.address);
 
     await contractVoucherKernel.setBosonRouterAddress(
       contractBosonRouter.address
@@ -1171,8 +1162,9 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
     await contractVoucherKernel.setCashierAddress(contractCashier.address);
 
     await contractCashier.setBosonRouterAddress(contractBosonRouter.address);
-    await contractCashier.setTokenContractAddress(contractERC1155ERC721.address);
-
+    await contractCashier.setTokenContractAddress(
+      contractERC1155ERC721.address
+    );
   }
 
   beforeEach('setup promise dates based on the block timestamp', async () => {

--- a/test/2_test_fullpath_with_permit.js
+++ b/test/2_test_fullpath_with_permit.js
@@ -61,7 +61,6 @@ contract('Cashier and VoucherKernel', async (addresses) => {
     contractCashier = await Cashier.new(contractVoucherKernel.address);
     contractBosonRouter = await BosonRouter.new(
       contractVoucherKernel.address,
-      contractERC1155ERC721.address,
       contractFundLimitsOracle.address,
       contractCashier.address
     );
@@ -79,19 +78,22 @@ contract('Cashier and VoucherKernel', async (addresses) => {
       contractVoucherKernel.address,
       'true'
     );
+
     await contractERC1155ERC721.setVoucherKernelAddress(
       contractVoucherKernel.address
     );
-    await contractERC1155ERC721.setBosonRouterAddress(
-      contractBosonRouter.address
-    );
 
+    await contractERC1155ERC721.setCashierAddress(
+      contractCashier.address
+    );
+   
     await contractVoucherKernel.setBosonRouterAddress(
       contractBosonRouter.address
     );
     await contractVoucherKernel.setCashierAddress(contractCashier.address);
 
     await contractCashier.setBosonRouterAddress(contractBosonRouter.address);
+    await contractCashier.setTokenContractAddress(contractERC1155ERC721.address);
 
     await contractVoucherKernel.setComplainPeriod(sixtySeconds);
     await contractVoucherKernel.setCancelFaultPeriod(sixtySeconds);

--- a/test/2_test_fullpath_with_permit.js
+++ b/test/2_test_fullpath_with_permit.js
@@ -83,17 +83,17 @@ contract('Cashier and VoucherKernel', async (addresses) => {
       contractVoucherKernel.address
     );
 
-    await contractERC1155ERC721.setCashierAddress(
-      contractCashier.address
-    );
-   
+    await contractERC1155ERC721.setCashierAddress(contractCashier.address);
+
     await contractVoucherKernel.setBosonRouterAddress(
       contractBosonRouter.address
     );
     await contractVoucherKernel.setCashierAddress(contractCashier.address);
 
     await contractCashier.setBosonRouterAddress(contractBosonRouter.address);
-    await contractCashier.setTokenContractAddress(contractERC1155ERC721.address);
+    await contractCashier.setTokenContractAddress(
+      contractERC1155ERC721.address
+    );
 
     await contractVoucherKernel.setComplainPeriod(sixtySeconds);
     await contractVoucherKernel.setCancelFaultPeriod(sixtySeconds);

--- a/test/3_withdrawals.js
+++ b/test/3_withdrawals.js
@@ -46,7 +46,6 @@ contract('Cashier withdrawals ', async (addresses) => {
     contractCashier = await Cashier.new(contractVoucherKernel.address);
     contractBosonRouter = await BosonRouter.new(
       contractVoucherKernel.address,
-      contractERC1155ERC721.address,
       contractFundLimitsOracle.address,
       contractCashier.address
     );
@@ -66,16 +65,19 @@ contract('Cashier withdrawals ', async (addresses) => {
     await contractERC1155ERC721.setVoucherKernelAddress(
       contractVoucherKernel.address
     );
-    await contractERC1155ERC721.setBosonRouterAddress(
-      contractBosonRouter.address
-    );
-
+   
     await contractVoucherKernel.setBosonRouterAddress(
       contractBosonRouter.address
     );
+
+    await contractERC1155ERC721.setCashierAddress(
+      contractCashier.address
+    );
+    
     await contractVoucherKernel.setCashierAddress(contractCashier.address);
 
     await contractCashier.setBosonRouterAddress(contractBosonRouter.address);
+    await contractCashier.setTokenContractAddress(contractERC1155ERC721.address);
 
     await contractFundLimitsOracle.setTokenLimit(
       contractBSNTokenPrice.address,

--- a/test/3_withdrawals.js
+++ b/test/3_withdrawals.js
@@ -65,19 +65,19 @@ contract('Cashier withdrawals ', async (addresses) => {
     await contractERC1155ERC721.setVoucherKernelAddress(
       contractVoucherKernel.address
     );
-   
+
     await contractVoucherKernel.setBosonRouterAddress(
       contractBosonRouter.address
     );
 
-    await contractERC1155ERC721.setCashierAddress(
-      contractCashier.address
-    );
-    
+    await contractERC1155ERC721.setCashierAddress(contractCashier.address);
+
     await contractVoucherKernel.setCashierAddress(contractCashier.address);
 
     await contractCashier.setBosonRouterAddress(contractBosonRouter.address);
-    await contractCashier.setTokenContractAddress(contractERC1155ERC721.address);
+    await contractCashier.setTokenContractAddress(
+      contractERC1155ERC721.address
+    );
 
     await contractFundLimitsOracle.setTokenLimit(
       contractBSNTokenPrice.address,

--- a/test/4_pausing_contracts.js
+++ b/test/4_pausing_contracts.js
@@ -44,7 +44,6 @@ contract('Cashier && VK', async (addresses) => {
     contractCashier = await Cashier.new(contractVoucherKernel.address);
     contractBosonRouter = await BosonRouter.new(
       contractVoucherKernel.address,
-      contractERC1155ERC721.address,
       contractFundLimitsOracle.address,
       contractCashier.address
     );
@@ -61,19 +60,22 @@ contract('Cashier && VK', async (addresses) => {
       contractVoucherKernel.address,
       'true'
     );
+
     await contractERC1155ERC721.setVoucherKernelAddress(
       contractVoucherKernel.address
     );
-    await contractERC1155ERC721.setBosonRouterAddress(
-      contractBosonRouter.address
-    );
 
+    await contractERC1155ERC721.setCashierAddress(
+      contractCashier.address
+    );
+   
     await contractVoucherKernel.setBosonRouterAddress(
       contractBosonRouter.address
     );
     await contractVoucherKernel.setCashierAddress(contractCashier.address);
 
     await contractCashier.setBosonRouterAddress(contractBosonRouter.address);
+    await contractCashier.setTokenContractAddress(contractERC1155ERC721.address);
 
     await contractVoucherKernel.setComplainPeriod(60); //60 seconds
     await contractVoucherKernel.setCancelFaultPeriod(60); //60 seconds

--- a/test/4_pausing_contracts.js
+++ b/test/4_pausing_contracts.js
@@ -65,17 +65,17 @@ contract('Cashier && VK', async (addresses) => {
       contractVoucherKernel.address
     );
 
-    await contractERC1155ERC721.setCashierAddress(
-      contractCashier.address
-    );
-   
+    await contractERC1155ERC721.setCashierAddress(contractCashier.address);
+
     await contractVoucherKernel.setBosonRouterAddress(
       contractBosonRouter.address
     );
     await contractVoucherKernel.setCashierAddress(contractCashier.address);
 
     await contractCashier.setBosonRouterAddress(contractBosonRouter.address);
-    await contractCashier.setTokenContractAddress(contractERC1155ERC721.address);
+    await contractCashier.setTokenContractAddress(
+      contractERC1155ERC721.address
+    );
 
     await contractVoucherKernel.setComplainPeriod(60); //60 seconds
     await contractVoucherKernel.setCancelFaultPeriod(60); //60 seconds

--- a/test/5_fundLimits.js
+++ b/test/5_fundLimits.js
@@ -58,9 +58,7 @@ contract('FundLimitsOracle', async (addresses) => {
       contractVoucherKernel.address
     );
 
-    await contractERC1155ERC721.setCashierAddress(
-      contractCashier.address
-    );
+    await contractERC1155ERC721.setCashierAddress(contractCashier.address);
 
     await contractVoucherKernel.setBosonRouterAddress(
       contractBosonRouter.address
@@ -69,7 +67,9 @@ contract('FundLimitsOracle', async (addresses) => {
     await contractVoucherKernel.setCashierAddress(contractCashier.address);
 
     await contractCashier.setBosonRouterAddress(contractBosonRouter.address);
-    await contractCashier.setTokenContractAddress(contractERC1155ERC721.address);
+    await contractCashier.setTokenContractAddress(
+      contractERC1155ERC721.address
+    );
   }
 
   describe('FundLimitsOracle interaction', () => {

--- a/test/5_fundLimits.js
+++ b/test/5_fundLimits.js
@@ -41,7 +41,6 @@ contract('FundLimitsOracle', async (addresses) => {
     contractCashier = await Cashier.new(contractVoucherKernel.address);
     contractBosonRouter = await BosonRouter.new(
       contractVoucherKernel.address,
-      contractERC1155ERC721.address,
       contractFundLimitsOracle.address,
       contractCashier.address
     );
@@ -58,16 +57,19 @@ contract('FundLimitsOracle', async (addresses) => {
     await contractERC1155ERC721.setVoucherKernelAddress(
       contractVoucherKernel.address
     );
-    await contractERC1155ERC721.setBosonRouterAddress(
-      contractBosonRouter.address
+
+    await contractERC1155ERC721.setCashierAddress(
+      contractCashier.address
     );
 
     await contractVoucherKernel.setBosonRouterAddress(
       contractBosonRouter.address
     );
+
     await contractVoucherKernel.setCashierAddress(contractCashier.address);
 
     await contractCashier.setBosonRouterAddress(contractBosonRouter.address);
+    await contractCashier.setTokenContractAddress(contractERC1155ERC721.address);
   }
 
   describe('FundLimitsOracle interaction', () => {

--- a/test/6_erc1155721.js
+++ b/test/6_erc1155721.js
@@ -55,22 +55,22 @@ contract('ERC1155ERC721', async (addresses) => {
       contractVoucherKernel.address,
       'true'
     );
-    
+
     await contractERC1155ERC721.setVoucherKernelAddress(
       contractVoucherKernel.address
     );
 
-    await contractERC1155ERC721.setCashierAddress(
-      contractCashier.address
-    );
-   
+    await contractERC1155ERC721.setCashierAddress(contractCashier.address);
+
     await contractVoucherKernel.setBosonRouterAddress(
       contractBosonRouter.address
     );
     await contractVoucherKernel.setCashierAddress(contractCashier.address);
 
     await contractCashier.setBosonRouterAddress(contractBosonRouter.address);
-    await contractCashier.setTokenContractAddress(contractERC1155ERC721.address);
+    await contractCashier.setTokenContractAddress(
+      contractERC1155ERC721.address
+    );
 
     await contractVoucherKernel.setComplainPeriod(60); //60 seconds
     await contractVoucherKernel.setCancelFaultPeriod(60); //60 seconds

--- a/test/6_erc1155721.js
+++ b/test/6_erc1155721.js
@@ -39,7 +39,6 @@ contract('ERC1155ERC721', async (addresses) => {
     contractCashier = await Cashier.new(contractVoucherKernel.address);
     contractBosonRouter = await BosonRouter.new(
       contractVoucherKernel.address,
-      contractERC1155ERC721.address,
       contractFundLimitsOracle.address,
       contractCashier.address
     );
@@ -56,19 +55,22 @@ contract('ERC1155ERC721', async (addresses) => {
       contractVoucherKernel.address,
       'true'
     );
+    
     await contractERC1155ERC721.setVoucherKernelAddress(
       contractVoucherKernel.address
     );
-    await contractERC1155ERC721.setBosonRouterAddress(
-      contractBosonRouter.address
-    );
 
+    await contractERC1155ERC721.setCashierAddress(
+      contractCashier.address
+    );
+   
     await contractVoucherKernel.setBosonRouterAddress(
       contractBosonRouter.address
     );
     await contractVoucherKernel.setCashierAddress(contractCashier.address);
 
     await contractCashier.setBosonRouterAddress(contractBosonRouter.address);
+    await contractCashier.setTokenContractAddress(contractERC1155ERC721.address);
 
     await contractVoucherKernel.setComplainPeriod(60); //60 seconds
     await contractVoucherKernel.setCancelFaultPeriod(60); //60 seconds
@@ -77,10 +79,12 @@ contract('ERC1155ERC721', async (addresses) => {
       contractBSNTokenPrice.address,
       constants.TOKEN_LIMIT
     );
+
     await contractFundLimitsOracle.setTokenLimit(
       contractBSNTokenDeposit.address,
       constants.TOKEN_LIMIT
     );
+
     await contractFundLimitsOracle.setETHLimit(constants.ETHER_LIMIT);
   }
 
@@ -174,42 +178,6 @@ contract('ERC1155ERC721', async (addresses) => {
             ev._newVoucherKernel,
             contractVoucherKernel.address,
             'VK not as expected!'
-          );
-          assert.equal(
-            ev._triggeredBy,
-            users.deployer.address,
-            '_triggeredBy not as expected!'
-          );
-          return true;
-        });
-      });
-
-      it('[NEGATIVE][setBosonRouterAddress] Should revert if executed by attacker', async () => {
-        await truffleAssert.reverts(
-          contractERC1155ERC721.setBosonRouterAddress(
-            contractBosonRouter.address,
-            {from: users.attacker.address}
-          ),
-          truffleAssert.ErrorType.REVERT
-        );
-      });
-
-      it('[NEGATIVE][setBosonRouterAddress] Should revert if ZERO address is provided', async () => {
-        await truffleAssert.reverts(
-          contractERC1155ERC721.setBosonRouterAddress(constants.ZERO_ADDRESS),
-          truffleAssert.ErrorType.REVERT
-        );
-      });
-
-      it('[setBosonRouterAddress] Should emit LogBosonRouterSet', async () => {
-        const tx = await contractERC1155ERC721.setBosonRouterAddress(
-          contractBosonRouter.address
-        );
-        truffleAssert.eventEmitted(tx, 'LogBosonRouterSet', (ev) => {
-          assert.equal(
-            ev._newBosonRouter,
-            contractBosonRouter.address,
-            'BR not as expected!'
           );
           assert.equal(
             ev._triggeredBy,
@@ -330,44 +298,6 @@ contract('ERC1155ERC721', async (addresses) => {
       it('[NEGATIVE]Owner should not be able to set ZERO VK address', async () => {
         await truffleAssert.reverts(
           contractERC1155ERC721.setVoucherKernelAddress(constants.ZERO_ADDRESS),
-          truffleAssert.ErrorType.REVERT
-        );
-      });
-
-      it('Owner should be able to set BR address', async () => {
-        const tx = await contractERC1155ERC721.setBosonRouterAddress(
-          contractBosonRouter.address
-        );
-
-        truffleAssert.eventEmitted(tx, 'LogBosonRouterSet', (ev) => {
-          assert.equal(
-            ev._newBosonRouter,
-            contractBosonRouter.address,
-            'VK not as expected!'
-          );
-          assert.equal(
-            ev._triggeredBy,
-            users.deployer.address,
-            'LogBosonRouterSet not triggered by owner!'
-          );
-
-          return true;
-        });
-      });
-
-      it('[NEGATIVE] Attacker should not be able to set BR address', async () => {
-        await truffleAssert.reverts(
-          contractERC1155ERC721.setBosonRouterAddress(
-            contractBosonRouter.address,
-            {from: users.attacker.address}
-          ),
-          truffleAssert.ErrorType.REVERT
-        );
-      });
-
-      it('[NEGATIVE] Owner should not be able to set ZERO BR address', async () => {
-        await truffleAssert.reverts(
-          contractERC1155ERC721.setBosonRouterAddress(constants.ZERO_ADDRESS),
           truffleAssert.ErrorType.REVERT
         );
       });

--- a/test/6_erc1155721.js
+++ b/test/6_erc1155721.js
@@ -152,42 +152,6 @@ contract('ERC1155ERC721', async (addresses) => {
         });
       });
 
-      it('[NEGATIVE][setVoucherKernelAddress] Should revert if executed by attacker', async () => {
-        await truffleAssert.reverts(
-          contractERC1155ERC721.setVoucherKernelAddress(
-            contractVoucherKernel.address,
-            {from: users.attacker.address}
-          ),
-          truffleAssert.ErrorType.REVERT
-        );
-      });
-
-      it('[NEGATIVE][setVoucherKernelAddress] Should revert if ZERO address is provided', async () => {
-        await truffleAssert.reverts(
-          contractERC1155ERC721.setVoucherKernelAddress(constants.ZERO_ADDRESS),
-          truffleAssert.ErrorType.REVERT
-        );
-      });
-
-      it('[setVoucherKernelAddress] Should emit LogVoucherKernelSet', async () => {
-        const tx = await contractERC1155ERC721.setVoucherKernelAddress(
-          contractVoucherKernel.address
-        );
-        truffleAssert.eventEmitted(tx, 'LogVoucherKernelSet', (ev) => {
-          assert.equal(
-            ev._newVoucherKernel,
-            contractVoucherKernel.address,
-            'VK not as expected!'
-          );
-          assert.equal(
-            ev._triggeredBy,
-            users.deployer.address,
-            '_triggeredBy not as expected!'
-          );
-          return true;
-        });
-      });
-
       it('Should emit TransferSingle event', async () => {
         let txFillOrder = await utils.createOrder(
           users.seller,
@@ -255,51 +219,6 @@ contract('ERC1155ERC721', async (addresses) => {
           assert.equal(ev._to, users.buyer.address, '_to not expected!');
           return true;
         });
-      });
-
-      it('Owner should be the deployer', async () => {
-        let expectedOwner = users.deployer.address;
-        let owner = await contractERC1155ERC721.owner();
-
-        assert.equal(owner, expectedOwner, 'Owner is not as expected');
-      });
-
-      it('Owner should be able to set VK address', async () => {
-        const tx = await contractERC1155ERC721.setVoucherKernelAddress(
-          contractVoucherKernel.address
-        );
-
-        truffleAssert.eventEmitted(tx, 'LogVoucherKernelSet', (ev) => {
-          assert.equal(
-            ev._newVoucherKernel,
-            contractVoucherKernel.address,
-            'VK not as expected!'
-          );
-          assert.equal(
-            ev._triggeredBy,
-            users.deployer.address,
-            'LogVoucherKernelSet not triggered by owner!'
-          );
-
-          return true;
-        });
-      });
-
-      it('[NEGATIVE]Attacker should not be able to set VK address', async () => {
-        await truffleAssert.reverts(
-          contractERC1155ERC721.setVoucherKernelAddress(
-            contractVoucherKernel.address,
-            {from: users.attacker.address}
-          ),
-          truffleAssert.ErrorType.REVERT
-        );
-      });
-
-      it('[NEGATIVE]Owner should not be able to set ZERO VK address', async () => {
-        await truffleAssert.reverts(
-          contractERC1155ERC721.setVoucherKernelAddress(constants.ZERO_ADDRESS),
-          truffleAssert.ErrorType.REVERT
-        );
       });
 
       it('Owner should approve transfer of erc721', async () => {

--- a/test/7_ admin_functionality.js
+++ b/test/7_ admin_functionality.js
@@ -126,7 +126,7 @@ contract('Admin functionality', async (addresses) => {
     });
   });
 
-  describe('ERC1125721', () => {
+  describe('ERC1155721', () => {
     before(async () => {
       await deployContracts();
     });

--- a/test/7_ admin_functionality.js
+++ b/test/7_ admin_functionality.js
@@ -1,0 +1,326 @@
+const {assert} = require('chai');
+const truffleAssert = require('truffle-assertions');
+
+const constants = require('../testHelpers/constants');
+const Users = require('../testHelpers/users');
+const Utils = require('../testHelpers/utils');
+
+const ERC1155ERC721 = artifacts.require('ERC1155ERC721');
+const VoucherKernel = artifacts.require('VoucherKernel');
+const Cashier = artifacts.require('Cashier');
+const BosonRouter = artifacts.require('BosonRouter');
+const MockERC20Permit = artifacts.require('MockERC20Permit');
+const FundLimitsOracle = artifacts.require('FundLimitsOracle');
+
+contract('Admin functionality', async (addresses) => {
+  const users = new Users(addresses);
+
+  let contractERC1155ERC721,
+    contractVoucherKernel,
+    contractCashier,
+    contractBosonRouter,
+    contractBSNTokenPrice,
+    contractFundLimitsOracle;
+  let expectedLimit;
+
+
+  async function deployContracts() {
+    const timestamp = await Utils.getCurrTimestamp();
+
+    constants.PROMISE_VALID_FROM = timestamp;
+    constants.PROMISE_VALID_TO = timestamp + 2 * constants.SECONDS_IN_DAY;
+
+    contractFundLimitsOracle = await FundLimitsOracle.new();
+
+    contractERC1155ERC721 = await ERC1155ERC721.new();
+    contractVoucherKernel = await VoucherKernel.new(
+      contractERC1155ERC721.address
+    );
+    contractCashier = await Cashier.new(contractVoucherKernel.address);
+    contractBosonRouter = await BosonRouter.new(
+      contractVoucherKernel.address,
+      contractFundLimitsOracle.address,
+      contractCashier.address
+    );
+
+    contractBSNTokenPrice = await MockERC20Permit.new(
+      'BosonTokenPrice',
+      'BPRC'
+    );
+  }
+
+  describe('Cashier', () => {
+    before(async () => {
+      await deployContracts();
+    });
+
+    it('Owner should be the deployer', async () => {
+        let expectedOwner = users.deployer.address;
+        let owner = await contractCashier.owner();
+
+        assert.equal(owner, expectedOwner, 'Owner is not as expected');
+    });
+
+    it('Owner should be able to set BR address', async () => {
+        const tx = await contractCashier.setBosonRouterAddress(
+            contractBosonRouter.address
+        );
+
+        truffleAssert.eventEmitted(tx, 'LogBosonRouterSet', (ev) => {
+          assert.equal(
+            ev._newBosonRouter,
+            contractBosonRouter.address,
+            'BR not as expected!'
+          );
+          assert.equal(
+            ev._triggeredBy,
+            users.deployer.address,
+            'LogBosonRouterSet not triggered by owner!'
+          );
+
+          return true;
+        });
+      });
+      
+      
+      it('[NEGATIVE][setBosonRouterAddress] Should revert if executed by attacker', async () => {
+        await truffleAssert.reverts(
+            contractCashier.setBosonRouterAddress(
+            contractBosonRouter.address,
+            {from: users.attacker.address}
+          ),
+          truffleAssert.ErrorType.REVERT
+        );
+      });
+      
+      
+      it('[NEGATIVE][setBosonRouterAddress] Should revert if ZERO address is provided', async () => {
+        await truffleAssert.reverts(
+            contractCashier.setBosonRouterAddress(constants.ZERO_ADDRESS),
+          truffleAssert.ErrorType.REVERT
+        );
+      });
+
+      it('Owner should be able to set token contract address', async () => {
+        const tx = await contractCashier.setTokenContractAddress(
+            contractERC1155ERC721.address
+        );
+
+        truffleAssert.eventEmitted(tx, 'LogTokenContractSet', (ev) => {
+          assert.equal(
+            ev._newTokenContract,
+            contractERC1155ERC721.address,
+            'Token contract not as expected!'
+          );
+          assert.equal(
+            ev._triggeredBy,
+            users.deployer.address,
+            'LogTokenContractSet not triggered by owner!'
+          );
+
+          return true;
+        });
+      });
+      
+      
+      it('[NEGATIVE][setTokenContractAddress] Should revert if executed by attacker', async () => {
+        await truffleAssert.reverts(
+            contractCashier.setTokenContractAddress(
+                contractERC1155ERC721.address,
+            {from: users.attacker.address}
+          ),
+          truffleAssert.ErrorType.REVERT
+        );
+      });
+      
+      
+      it('[NEGATIVE][setTokenContractAddress] Should revert if ZERO address is provided', async () => {
+        await truffleAssert.reverts(
+            contractCashier.setTokenContractAddress(constants.ZERO_ADDRESS),
+          truffleAssert.ErrorType.REVERT
+        );
+      });
+    
+  });
+
+  describe('ERC1125721', () => {
+    before(async () => {
+        await deployContracts();
+    });
+
+    it('Owner should be the deployer', async () => {
+        let expectedOwner = users.deployer.address;
+        let owner = await contractERC1155ERC721.owner();
+
+        assert.equal(owner, expectedOwner, 'Owner is not as expected');
+    });
+
+    it('Owner should be able to set VK address', async () => {
+        const tx = await contractERC1155ERC721.setVoucherKernelAddress(
+          contractVoucherKernel.address
+        );
+
+        truffleAssert.eventEmitted(tx, 'LogVoucherKernelSet', (ev) => {
+          assert.equal(
+            ev._newVoucherKernel,
+            contractVoucherKernel.address,
+            'VK not as expected!'
+          );
+          assert.equal(
+            ev._triggeredBy,
+            users.deployer.address,
+            'LogVoucherKernelSet not triggered by owner!'
+          );
+
+          return true;
+        });
+    });
+
+    it('[NEGATIVE][setVoucherKernelAddress] Should revert if executed by attacker', async () => {
+        await truffleAssert.reverts(
+          contractERC1155ERC721.setVoucherKernelAddress(
+            contractVoucherKernel.address,
+            {from: users.attacker.address}
+          ),
+          truffleAssert.ErrorType.REVERT
+        );
+      });
+
+    it('[NEGATIVE][setVoucherKernelAddress] Should revert if ZERO address is provided', async () => {
+        await truffleAssert.reverts(
+            contractERC1155ERC721.setVoucherKernelAddress(constants.ZERO_ADDRESS),
+            truffleAssert.ErrorType.REVERT
+        );
+    });
+
+    it('Owner should be able to set Cashier address', async () => {
+        const tx = await contractERC1155ERC721.setCashierAddress(
+          contractCashier.address
+        );
+
+        truffleAssert.eventEmitted(tx, 'LogCashierSet', (ev) => {
+          assert.equal(
+            ev._newCashier,
+            contractCashier.address,
+            'Cashier not as expected!'
+          );
+          assert.equal(
+            ev._triggeredBy,
+            users.deployer.address,
+            'LogCashierSet not triggered by owner!'
+          );
+
+          return true;
+        });
+      });
+
+      it('[NEGATIVE][setCashierAddress] Attacker should not be able to set Cashier address', async () => {
+        await truffleAssert.reverts(
+          contractERC1155ERC721.setCashierAddress(
+            contractCashier.address,
+            {from: users.attacker.address}
+          ),
+          truffleAssert.ErrorType.REVERT
+        );
+      });
+
+      it('[NEGATIVE][setCashierAddress] Owner should not be able to set ZERO Cashier address', async () => {
+        await truffleAssert.reverts(
+          contractERC1155ERC721.setCashierAddress(constants.ZERO_ADDRESS),
+          truffleAssert.ErrorType.REVERT
+        );
+      });
+    });
+
+   describe('VoucherKernel', () => {
+        before(async () => {
+            await deployContracts();
+        });
+
+        it('Owner should be the deployer', async () => {
+            let expectedOwner = users.deployer.address;
+            let owner = await contractVoucherKernel.owner();
+    
+            assert.equal(owner, expectedOwner, 'Owner is not as expected');
+        });
+
+        it('Owner should be able to set Cashier address', async () => {
+            const tx = await contractVoucherKernel.setCashierAddress(
+              contractCashier.address
+            );
+    
+            truffleAssert.eventEmitted(tx, 'LogCashierSet', (ev) => {
+              assert.equal(
+                ev._newCashier,
+                contractCashier.address,
+                'Cashier not as expected!'
+              );
+              assert.equal(
+                ev._triggeredBy,
+                users.deployer.address,
+                'LogCashierSet not triggered by owner!'
+              );
+    
+              return true;
+            });
+          });
+    
+        it('[NEGATIVE][setCashierAddress] Attacker should not be able to set Cashier address', async () => {
+            await truffleAssert.reverts(
+                contractVoucherKernel.setCashierAddress(
+                contractCashier.address,
+                {from: users.attacker.address}
+                ),
+                truffleAssert.ErrorType.REVERT
+            );
+        });
+    
+        it('[NEGATIVE][setCashierAddress] Owner should not be able to set ZERO Cashier address', async () => {
+            await truffleAssert.reverts(
+                contractVoucherKernel.setCashierAddress(constants.ZERO_ADDRESS),
+                truffleAssert.ErrorType.REVERT
+            );
+        });
+
+        it('Owner should be able to set BR address', async () => {
+            const tx = await contractVoucherKernel.setBosonRouterAddress(
+                contractBosonRouter.address
+            );
+    
+            truffleAssert.eventEmitted(tx, 'LogBosonRouterSet', (ev) => {
+              assert.equal(
+                ev._newBosonRouter,
+                contractBosonRouter.address,
+                'BR not as expected!'
+              );
+              assert.equal(
+                ev._triggeredBy,
+                users.deployer.address,
+                'LogBosonRouterSet not triggered by owner!'
+              );
+    
+              return true;
+            });
+          });
+          
+          
+          it('[NEGATIVE][setBosonRouterAddress] Should revert if executed by attacker', async () => {
+            await truffleAssert.reverts(
+                contractVoucherKernel.setBosonRouterAddress(
+                contractBosonRouter.address,
+                {from: users.attacker.address}
+              ),
+              truffleAssert.ErrorType.REVERT
+            );
+          });
+          
+          
+          it('[NEGATIVE][setBosonRouterAddress] Should revert if ZERO address is provided', async () => {
+            await truffleAssert.reverts(
+                contractVoucherKernel.setBosonRouterAddress(constants.ZERO_ADDRESS),
+              truffleAssert.ErrorType.REVERT
+            );
+          });
+        
+    });
+});//end of contract

--- a/test/7_ admin_functionality.js
+++ b/test/7_ admin_functionality.js
@@ -23,7 +23,6 @@ contract('Admin functionality', async (addresses) => {
     contractFundLimitsOracle;
   let expectedLimit;
 
-
   async function deployContracts() {
     const timestamp = await Utils.getCurrTimestamp();
 
@@ -55,272 +54,260 @@ contract('Admin functionality', async (addresses) => {
     });
 
     it('Owner should be the deployer', async () => {
-        let expectedOwner = users.deployer.address;
-        let owner = await contractCashier.owner();
+      let expectedOwner = users.deployer.address;
+      let owner = await contractCashier.owner();
 
-        assert.equal(owner, expectedOwner, 'Owner is not as expected');
+      assert.equal(owner, expectedOwner, 'Owner is not as expected');
     });
 
     it('Owner should be able to set BR address', async () => {
-        const tx = await contractCashier.setBosonRouterAddress(
-            contractBosonRouter.address
+      const tx = await contractCashier.setBosonRouterAddress(
+        contractBosonRouter.address
+      );
+
+      truffleAssert.eventEmitted(tx, 'LogBosonRouterSet', (ev) => {
+        assert.equal(
+          ev._newBosonRouter,
+          contractBosonRouter.address,
+          'BR not as expected!'
+        );
+        assert.equal(
+          ev._triggeredBy,
+          users.deployer.address,
+          'LogBosonRouterSet not triggered by owner!'
         );
 
-        truffleAssert.eventEmitted(tx, 'LogBosonRouterSet', (ev) => {
-          assert.equal(
-            ev._newBosonRouter,
-            contractBosonRouter.address,
-            'BR not as expected!'
-          );
-          assert.equal(
-            ev._triggeredBy,
-            users.deployer.address,
-            'LogBosonRouterSet not triggered by owner!'
-          );
+        return true;
+      });
+    });
 
-          return true;
-        });
-      });
-      
-      
-      it('[NEGATIVE][setBosonRouterAddress] Should revert if executed by attacker', async () => {
-        await truffleAssert.reverts(
-            contractCashier.setBosonRouterAddress(
-            contractBosonRouter.address,
-            {from: users.attacker.address}
-          ),
-          truffleAssert.ErrorType.REVERT
-        );
-      });
-      
-      
-      it('[NEGATIVE][setBosonRouterAddress] Should revert if ZERO address is provided', async () => {
-        await truffleAssert.reverts(
-            contractCashier.setBosonRouterAddress(constants.ZERO_ADDRESS),
-          truffleAssert.ErrorType.REVERT
-        );
-      });
+    it('[NEGATIVE][setBosonRouterAddress] Should revert if executed by attacker', async () => {
+      await truffleAssert.reverts(
+        contractCashier.setBosonRouterAddress(contractBosonRouter.address, {
+          from: users.attacker.address,
+        }),
+        truffleAssert.ErrorType.REVERT
+      );
+    });
 
-      it('Owner should be able to set token contract address', async () => {
-        const tx = await contractCashier.setTokenContractAddress(
-            contractERC1155ERC721.address
+    it('[NEGATIVE][setBosonRouterAddress] Should revert if ZERO address is provided', async () => {
+      await truffleAssert.reverts(
+        contractCashier.setBosonRouterAddress(constants.ZERO_ADDRESS),
+        truffleAssert.ErrorType.REVERT
+      );
+    });
+
+    it('Owner should be able to set token contract address', async () => {
+      const tx = await contractCashier.setTokenContractAddress(
+        contractERC1155ERC721.address
+      );
+
+      truffleAssert.eventEmitted(tx, 'LogTokenContractSet', (ev) => {
+        assert.equal(
+          ev._newTokenContract,
+          contractERC1155ERC721.address,
+          'Token contract not as expected!'
+        );
+        assert.equal(
+          ev._triggeredBy,
+          users.deployer.address,
+          'LogTokenContractSet not triggered by owner!'
         );
 
-        truffleAssert.eventEmitted(tx, 'LogTokenContractSet', (ev) => {
-          assert.equal(
-            ev._newTokenContract,
-            contractERC1155ERC721.address,
-            'Token contract not as expected!'
-          );
-          assert.equal(
-            ev._triggeredBy,
-            users.deployer.address,
-            'LogTokenContractSet not triggered by owner!'
-          );
+        return true;
+      });
+    });
 
-          return true;
-        });
-      });
-      
-      
-      it('[NEGATIVE][setTokenContractAddress] Should revert if executed by attacker', async () => {
-        await truffleAssert.reverts(
-            contractCashier.setTokenContractAddress(
-                contractERC1155ERC721.address,
-            {from: users.attacker.address}
-          ),
-          truffleAssert.ErrorType.REVERT
-        );
-      });
-      
-      
-      it('[NEGATIVE][setTokenContractAddress] Should revert if ZERO address is provided', async () => {
-        await truffleAssert.reverts(
-            contractCashier.setTokenContractAddress(constants.ZERO_ADDRESS),
-          truffleAssert.ErrorType.REVERT
-        );
-      });
-    
+    it('[NEGATIVE][setTokenContractAddress] Should revert if executed by attacker', async () => {
+      await truffleAssert.reverts(
+        contractCashier.setTokenContractAddress(contractERC1155ERC721.address, {
+          from: users.attacker.address,
+        }),
+        truffleAssert.ErrorType.REVERT
+      );
+    });
+
+    it('[NEGATIVE][setTokenContractAddress] Should revert if ZERO address is provided', async () => {
+      await truffleAssert.reverts(
+        contractCashier.setTokenContractAddress(constants.ZERO_ADDRESS),
+        truffleAssert.ErrorType.REVERT
+      );
+    });
   });
 
   describe('ERC1125721', () => {
     before(async () => {
-        await deployContracts();
+      await deployContracts();
     });
 
     it('Owner should be the deployer', async () => {
-        let expectedOwner = users.deployer.address;
-        let owner = await contractERC1155ERC721.owner();
+      let expectedOwner = users.deployer.address;
+      let owner = await contractERC1155ERC721.owner();
 
-        assert.equal(owner, expectedOwner, 'Owner is not as expected');
+      assert.equal(owner, expectedOwner, 'Owner is not as expected');
     });
 
     it('Owner should be able to set VK address', async () => {
-        const tx = await contractERC1155ERC721.setVoucherKernelAddress(
-          contractVoucherKernel.address
+      const tx = await contractERC1155ERC721.setVoucherKernelAddress(
+        contractVoucherKernel.address
+      );
+
+      truffleAssert.eventEmitted(tx, 'LogVoucherKernelSet', (ev) => {
+        assert.equal(
+          ev._newVoucherKernel,
+          contractVoucherKernel.address,
+          'VK not as expected!'
+        );
+        assert.equal(
+          ev._triggeredBy,
+          users.deployer.address,
+          'LogVoucherKernelSet not triggered by owner!'
         );
 
-        truffleAssert.eventEmitted(tx, 'LogVoucherKernelSet', (ev) => {
-          assert.equal(
-            ev._newVoucherKernel,
-            contractVoucherKernel.address,
-            'VK not as expected!'
-          );
-          assert.equal(
-            ev._triggeredBy,
-            users.deployer.address,
-            'LogVoucherKernelSet not triggered by owner!'
-          );
-
-          return true;
-        });
+        return true;
+      });
     });
 
     it('[NEGATIVE][setVoucherKernelAddress] Should revert if executed by attacker', async () => {
-        await truffleAssert.reverts(
-          contractERC1155ERC721.setVoucherKernelAddress(
-            contractVoucherKernel.address,
-            {from: users.attacker.address}
-          ),
-          truffleAssert.ErrorType.REVERT
-        );
-      });
+      await truffleAssert.reverts(
+        contractERC1155ERC721.setVoucherKernelAddress(
+          contractVoucherKernel.address,
+          {from: users.attacker.address}
+        ),
+        truffleAssert.ErrorType.REVERT
+      );
+    });
 
     it('[NEGATIVE][setVoucherKernelAddress] Should revert if ZERO address is provided', async () => {
-        await truffleAssert.reverts(
-            contractERC1155ERC721.setVoucherKernelAddress(constants.ZERO_ADDRESS),
-            truffleAssert.ErrorType.REVERT
-        );
+      await truffleAssert.reverts(
+        contractERC1155ERC721.setVoucherKernelAddress(constants.ZERO_ADDRESS),
+        truffleAssert.ErrorType.REVERT
+      );
     });
 
     it('Owner should be able to set Cashier address', async () => {
-        const tx = await contractERC1155ERC721.setCashierAddress(
-          contractCashier.address
+      const tx = await contractERC1155ERC721.setCashierAddress(
+        contractCashier.address
+      );
+
+      truffleAssert.eventEmitted(tx, 'LogCashierSet', (ev) => {
+        assert.equal(
+          ev._newCashier,
+          contractCashier.address,
+          'Cashier not as expected!'
+        );
+        assert.equal(
+          ev._triggeredBy,
+          users.deployer.address,
+          'LogCashierSet not triggered by owner!'
         );
 
-        truffleAssert.eventEmitted(tx, 'LogCashierSet', (ev) => {
-          assert.equal(
-            ev._newCashier,
-            contractCashier.address,
-            'Cashier not as expected!'
-          );
-          assert.equal(
-            ev._triggeredBy,
-            users.deployer.address,
-            'LogCashierSet not triggered by owner!'
-          );
-
-          return true;
-        });
-      });
-
-      it('[NEGATIVE][setCashierAddress] Attacker should not be able to set Cashier address', async () => {
-        await truffleAssert.reverts(
-          contractERC1155ERC721.setCashierAddress(
-            contractCashier.address,
-            {from: users.attacker.address}
-          ),
-          truffleAssert.ErrorType.REVERT
-        );
-      });
-
-      it('[NEGATIVE][setCashierAddress] Owner should not be able to set ZERO Cashier address', async () => {
-        await truffleAssert.reverts(
-          contractERC1155ERC721.setCashierAddress(constants.ZERO_ADDRESS),
-          truffleAssert.ErrorType.REVERT
-        );
+        return true;
       });
     });
 
-   describe('VoucherKernel', () => {
-        before(async () => {
-            await deployContracts();
-        });
-
-        it('Owner should be the deployer', async () => {
-            let expectedOwner = users.deployer.address;
-            let owner = await contractVoucherKernel.owner();
-    
-            assert.equal(owner, expectedOwner, 'Owner is not as expected');
-        });
-
-        it('Owner should be able to set Cashier address', async () => {
-            const tx = await contractVoucherKernel.setCashierAddress(
-              contractCashier.address
-            );
-    
-            truffleAssert.eventEmitted(tx, 'LogCashierSet', (ev) => {
-              assert.equal(
-                ev._newCashier,
-                contractCashier.address,
-                'Cashier not as expected!'
-              );
-              assert.equal(
-                ev._triggeredBy,
-                users.deployer.address,
-                'LogCashierSet not triggered by owner!'
-              );
-    
-              return true;
-            });
-          });
-    
-        it('[NEGATIVE][setCashierAddress] Attacker should not be able to set Cashier address', async () => {
-            await truffleAssert.reverts(
-                contractVoucherKernel.setCashierAddress(
-                contractCashier.address,
-                {from: users.attacker.address}
-                ),
-                truffleAssert.ErrorType.REVERT
-            );
-        });
-    
-        it('[NEGATIVE][setCashierAddress] Owner should not be able to set ZERO Cashier address', async () => {
-            await truffleAssert.reverts(
-                contractVoucherKernel.setCashierAddress(constants.ZERO_ADDRESS),
-                truffleAssert.ErrorType.REVERT
-            );
-        });
-
-        it('Owner should be able to set BR address', async () => {
-            const tx = await contractVoucherKernel.setBosonRouterAddress(
-                contractBosonRouter.address
-            );
-    
-            truffleAssert.eventEmitted(tx, 'LogBosonRouterSet', (ev) => {
-              assert.equal(
-                ev._newBosonRouter,
-                contractBosonRouter.address,
-                'BR not as expected!'
-              );
-              assert.equal(
-                ev._triggeredBy,
-                users.deployer.address,
-                'LogBosonRouterSet not triggered by owner!'
-              );
-    
-              return true;
-            });
-          });
-          
-          
-          it('[NEGATIVE][setBosonRouterAddress] Should revert if executed by attacker', async () => {
-            await truffleAssert.reverts(
-                contractVoucherKernel.setBosonRouterAddress(
-                contractBosonRouter.address,
-                {from: users.attacker.address}
-              ),
-              truffleAssert.ErrorType.REVERT
-            );
-          });
-          
-          
-          it('[NEGATIVE][setBosonRouterAddress] Should revert if ZERO address is provided', async () => {
-            await truffleAssert.reverts(
-                contractVoucherKernel.setBosonRouterAddress(constants.ZERO_ADDRESS),
-              truffleAssert.ErrorType.REVERT
-            );
-          });
-        
+    it('[NEGATIVE][setCashierAddress] Attacker should not be able to set Cashier address', async () => {
+      await truffleAssert.reverts(
+        contractERC1155ERC721.setCashierAddress(contractCashier.address, {
+          from: users.attacker.address,
+        }),
+        truffleAssert.ErrorType.REVERT
+      );
     });
-});//end of contract
+
+    it('[NEGATIVE][setCashierAddress] Owner should not be able to set ZERO Cashier address', async () => {
+      await truffleAssert.reverts(
+        contractERC1155ERC721.setCashierAddress(constants.ZERO_ADDRESS),
+        truffleAssert.ErrorType.REVERT
+      );
+    });
+  });
+
+  describe('VoucherKernel', () => {
+    before(async () => {
+      await deployContracts();
+    });
+
+    it('Owner should be the deployer', async () => {
+      let expectedOwner = users.deployer.address;
+      let owner = await contractVoucherKernel.owner();
+
+      assert.equal(owner, expectedOwner, 'Owner is not as expected');
+    });
+
+    it('Owner should be able to set Cashier address', async () => {
+      const tx = await contractVoucherKernel.setCashierAddress(
+        contractCashier.address
+      );
+
+      truffleAssert.eventEmitted(tx, 'LogCashierSet', (ev) => {
+        assert.equal(
+          ev._newCashier,
+          contractCashier.address,
+          'Cashier not as expected!'
+        );
+        assert.equal(
+          ev._triggeredBy,
+          users.deployer.address,
+          'LogCashierSet not triggered by owner!'
+        );
+
+        return true;
+      });
+    });
+
+    it('[NEGATIVE][setCashierAddress] Attacker should not be able to set Cashier address', async () => {
+      await truffleAssert.reverts(
+        contractVoucherKernel.setCashierAddress(contractCashier.address, {
+          from: users.attacker.address,
+        }),
+        truffleAssert.ErrorType.REVERT
+      );
+    });
+
+    it('[NEGATIVE][setCashierAddress] Owner should not be able to set ZERO Cashier address', async () => {
+      await truffleAssert.reverts(
+        contractVoucherKernel.setCashierAddress(constants.ZERO_ADDRESS),
+        truffleAssert.ErrorType.REVERT
+      );
+    });
+
+    it('Owner should be able to set BR address', async () => {
+      const tx = await contractVoucherKernel.setBosonRouterAddress(
+        contractBosonRouter.address
+      );
+
+      truffleAssert.eventEmitted(tx, 'LogBosonRouterSet', (ev) => {
+        assert.equal(
+          ev._newBosonRouter,
+          contractBosonRouter.address,
+          'BR not as expected!'
+        );
+        assert.equal(
+          ev._triggeredBy,
+          users.deployer.address,
+          'LogBosonRouterSet not triggered by owner!'
+        );
+
+        return true;
+      });
+    });
+
+    it('[NEGATIVE][setBosonRouterAddress] Should revert if executed by attacker', async () => {
+      await truffleAssert.reverts(
+        contractVoucherKernel.setBosonRouterAddress(
+          contractBosonRouter.address,
+          {from: users.attacker.address}
+        ),
+        truffleAssert.ErrorType.REVERT
+      );
+    });
+
+    it('[NEGATIVE][setBosonRouterAddress] Should revert if ZERO address is provided', async () => {
+      await truffleAssert.reverts(
+        contractVoucherKernel.setBosonRouterAddress(constants.ZERO_ADDRESS),
+        truffleAssert.ErrorType.REVERT
+      );
+    });
+  });
+}); //end of contract

--- a/test/7_ admin_functionality.js
+++ b/test/7_ admin_functionality.js
@@ -9,7 +9,6 @@ const ERC1155ERC721 = artifacts.require('ERC1155ERC721');
 const VoucherKernel = artifacts.require('VoucherKernel');
 const Cashier = artifacts.require('Cashier');
 const BosonRouter = artifacts.require('BosonRouter');
-const MockERC20Permit = artifacts.require('MockERC20Permit');
 const FundLimitsOracle = artifacts.require('FundLimitsOracle');
 
 contract('Admin functionality', async (addresses) => {
@@ -19,9 +18,7 @@ contract('Admin functionality', async (addresses) => {
     contractVoucherKernel,
     contractCashier,
     contractBosonRouter,
-    contractBSNTokenPrice,
     contractFundLimitsOracle;
-  let expectedLimit;
 
   async function deployContracts() {
     const timestamp = await Utils.getCurrTimestamp();
@@ -30,7 +27,6 @@ contract('Admin functionality', async (addresses) => {
     constants.PROMISE_VALID_TO = timestamp + 2 * constants.SECONDS_IN_DAY;
 
     contractFundLimitsOracle = await FundLimitsOracle.new();
-
     contractERC1155ERC721 = await ERC1155ERC721.new();
     contractVoucherKernel = await VoucherKernel.new(
       contractERC1155ERC721.address
@@ -40,11 +36,6 @@ contract('Admin functionality', async (addresses) => {
       contractVoucherKernel.address,
       contractFundLimitsOracle.address,
       contractCashier.address
-    );
-
-    contractBSNTokenPrice = await MockERC20Permit.new(
-      'BosonTokenPrice',
-      'BPRC'
     );
   }
 

--- a/testHelpers/constants.js
+++ b/testHelpers/constants.js
@@ -1,7 +1,11 @@
+const BN = require('bn.js');
+
 // common
 const ONE_MINUTE = 60;
 const SECONDS_IN_DAY = 86400;
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+const ZERO = new BN(0);
+const ONE = new BN(1);
 
 // asset
 const ASSET_VERSION = '0x3132';
@@ -89,4 +93,6 @@ module.exports = {
   ABOVE_ETH_LIMIT,
   TOKEN_LIMIT,
   ABOVE_TOKEN_LIMIT,
+  ZERO,
+  ONE,
 };


### PR DESCRIPTION
PR for story "Move hooks out of BosonRouter into Cashier contract"

Changes to contracts, migration scripts (new references from contracts to other contracts and removal of references required changes to deployment scripts), and tests. Also added a new test file to test new functions such as `Cashier.setBosonRouterAddress`,which didn't have a clear place in any of the current test files. Also moved existing test cases that already set address references on contracts and removed duplicates.

_beforeERC1155Transfer was removed because it included several calls that in the end just access the `balances` mapping in the calling contract(ERC1155721.sol).