### PR TITLE
Unittest fix

### DIFF
--- a/test/1_test_fullpath.js
+++ b/test/1_test_fullpath.js
@@ -1432,10 +1432,10 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
         tokenVoucherKey1
       );
 
-      //Check it didn't go into a branch that changes the complainPeriodStart
+      //Check it didn't go into a code branch that changes the complainPeriodStart
       assert.isTrue(
         voucherStatusAfter.complainPeriodStart.eq(
-          new BN(transactionBlock.timestamp)
+          voucherStatusBefore.complainPeriodStart
         )
       );
 


### PR DESCRIPTION
Changed the assertion at line 1436 in test case `refunding one voucher, then complain, then cancel/fault`. This test case failed intermittently, possibly because it was comparing  `complainPeriodStart`  to a block timestamp, which can be flakey. I changed the assertion to compare the `complainPeriodStart` after calling `cancelOrFault` to the `complainPeriodStart` before calling` cancelOrFault` because the `complainPeriodStart` shouldn't be changed by the `cancelOrFault` function in this situation.