### PR TITLE
Make state variables private

### DIFF
--- a/contracts/BosonRouter.sol
+++ b/contracts/BosonRouter.sol
@@ -26,7 +26,7 @@ contract BosonRouter is
     using Address for address payable;
     using SafeMath for uint256;
 
-    mapping(address => uint256) public correlationIds; // whenever a seller or a buyer interacts with the smart contract, a personal txID is emitted from an event.
+    mapping(address => uint256) private correlationIds; // whenever a seller or a buyer interacts with the smart contract, a personal txID is emitted from an event.
 
     using SafeMath for uint256;
 
@@ -692,10 +692,6 @@ contract BosonRouter is
         );
     }
 
-    // // // // // // // //
-    // UTILS
-    // // // // // // // //
-
     /**
      * @notice Increment a seller or buyer's correlation Id
      * @param _party   The address of the seller or buyer
@@ -705,5 +701,19 @@ contract BosonRouter is
         override
     {
          correlationIds[_party]++;
+    }
+
+    /**
+     * @notice Return a seller or buyer's correlation Id
+     * @param _party   The address of the seller or buyer
+     * @return the specified party's correlcation Id
+     */
+    function getCorrelationId(address _party) 
+        external
+        override
+        view
+        returns (uint256)
+    {
+        return correlationIds[_party];
     }
 }

--- a/contracts/BosonRouter.sol
+++ b/contracts/BosonRouter.sol
@@ -706,7 +706,7 @@ contract BosonRouter is
     /**
      * @notice Return a seller or buyer's correlation Id
      * @param _party   The address of the seller or buyer
-     * @return the specified party's correlcation Id
+     * @return the specified party's correlation Id
      */
     function getCorrelationId(address _party) 
         external

--- a/contracts/Cashier.sol
+++ b/contracts/Cashier.sol
@@ -22,16 +22,16 @@ contract Cashier is ICashier, UsingHelpers, ReentrancyGuard, Ownable, Pausable {
     using Address for address payable;
     using SafeMath for uint256;
 
-    address public voucherKernel;
-    address public bosonRouterAddress;
-    address public tokensContractAddress;
-    bool public disasterState;
+    address private voucherKernel;
+    address private bosonRouterAddress;
+    address private tokensContractAddress;
+    bool private disasterState;
 
     enum PaymentType {PAYMENT, DEPOSIT_SELLER, DEPOSIT_BUYER}
 
-    mapping(address => uint256) public escrow; // both types of deposits AND payments >> can be released token-by-token if checks pass
+    mapping(address => uint256) private escrow; // both types of deposits AND payments >> can be released token-by-token if checks pass
     // slashedDepositPool can be obtained through getEscrowAmount(poolAddress)
-    mapping(address => mapping(address => uint256)) public escrowTokens; //token address => mgsSender => amount
+    mapping(address => mapping(address => uint256)) private escrowTokens; //token address => mgsSender => amount
 
     uint256 internal constant CANCELFAULT_SPLIT = 2; //for POC purposes, this is hardcoded; e.g. each party gets depositSe / 2
 

--- a/contracts/Cashier.sol
+++ b/contracts/Cashier.sol
@@ -178,7 +178,10 @@ contract Cashier is ICashier, UsingHelpers, ReentrancyGuard, Ownable, Pausable {
         (
             voucherDetails.currStatus.status,
             voucherDetails.currStatus.isPaymentReleased,
-            voucherDetails.currStatus.isDepositsReleased
+            voucherDetails.currStatus.isDepositsReleased,
+            
+            ,
+
         ) = IVoucherKernel(voucherKernel).getVoucherStatus(
             voucherDetails.tokenIdVoucher
         );

--- a/contracts/Cashier.sol
+++ b/contracts/Cashier.sol
@@ -179,9 +179,7 @@ contract Cashier is ICashier, UsingHelpers, ReentrancyGuard, Ownable, Pausable {
             voucherDetails.currStatus.status,
             voucherDetails.currStatus.isPaymentReleased,
             voucherDetails.currStatus.isDepositsReleased,
-            
             ,
-
         ) = IVoucherKernel(voucherKernel).getVoucherStatus(
             voucherDetails.tokenIdVoucher
         );

--- a/contracts/ERC1155ERC721.sol
+++ b/contracts/ERC1155ERC721.sol
@@ -24,9 +24,9 @@ contract ERC1155ERC721 is IERC1155, IERC721, IERC1155ERC721 {
     using Address for address;
 
     //min security
-    address public owner; //contract owner
-    address public voucherKernelAddress; //address of the VoucherKernel contract
-    address public cashierAddress; //address of the Cashier contract
+    address private owner; //contract owner
+    address private voucherKernelAddress; //address of the VoucherKernel contract
+    address private cashierAddress; //address of the Cashier contract
 
     //standard reqs
     //ERC-1155

--- a/contracts/ERC1155ERC721.sol
+++ b/contracts/ERC1155ERC721.sol
@@ -861,4 +861,18 @@ contract ERC1155ERC721 is IERC1155, IERC721, IERC1155ERC721 {
         }
         return string(bstr);
     }
+
+    /**
+     * @notice Get the contract owner
+     * @return Address of the owner
+     */
+    function getOwner() 
+        external 
+        view 
+        override
+        returns (address)
+    {
+        return owner;
+    }
+    
 }

--- a/contracts/VoucherKernel.sol
+++ b/contracts/VoucherKernel.sol
@@ -1075,6 +1075,21 @@ contract VoucherKernel is IVoucherKernel, Ownable, Pausable, UsingHelpers {
     }
 
     /**
+     * @notice Get promise data not retrieved by other accessor functions
+     * @param _promiseKey   ID of the promise
+     * @return cancel or fault period
+     */
+    function getPromiseData(bytes32 _promiseKey)
+        external
+        view
+        override
+        returns (bytes32, uint256, uint256, uint256, uint256 )
+    {
+        Promise memory tPromise = promises[_promiseKey];
+        return (tPromise.promiseId, tPromise.nonce, tPromise.validFrom, tPromise.validTo, tPromise.idx); 
+    }
+
+    /**
      * @notice Get the current status of a voucher
      * @param _tokenIdVoucher   ID of the voucher token
      * @return                  Status of the voucher (via enum)
@@ -1086,13 +1101,17 @@ contract VoucherKernel is IVoucherKernel, Ownable, Pausable, UsingHelpers {
         returns (
             uint8,
             bool,
-            bool
+            bool,
+            uint256,
+            uint256
         )
     {
         return (
             vouchersStatus[_tokenIdVoucher].status,
             vouchersStatus[_tokenIdVoucher].isPaymentReleased,
-            vouchersStatus[_tokenIdVoucher].isDepositsReleased
+            vouchersStatus[_tokenIdVoucher].isDepositsReleased,
+            vouchersStatus[_tokenIdVoucher].complainPeriodStart,
+            vouchersStatus[_tokenIdVoucher].cancelFaultPeriodStart
         );
     }
 
@@ -1265,19 +1284,5 @@ contract VoucherKernel is IVoucherKernel, Ownable, Pausable, UsingHelpers {
         return cancelFaultPeriod;
     }
     
-    /**
-     * @notice Get promise data not retrieved by other accessor functions
-     * @param _tokenIdSupply   ID of the supply token
-     * @return cancel or fault period
-     */
-    function getPromiseData(uint256 _tokenIdSupply)
-        external
-        view
-        override
-        returns (bytes32, uint256, uint256, uint256, uint256 )
-    {
-        bytes32 promiseKey = ordersPromise[_tokenIdSupply];
-        Promise memory tPromise = promises[promiseKey];
-        return (tPromise.promiseId, tPromise.nonce, tPromise.validFrom, tPromise.validTo, tPromise.idx); 
-    }
+    
 }

--- a/contracts/VoucherKernel.sol
+++ b/contracts/VoucherKernel.sol
@@ -1061,7 +1061,7 @@ contract VoucherKernel is IVoucherKernel, Ownable, Pausable, UsingHelpers {
 
     /**
      * @notice Get the holder of a supply
-     * @param _tokenIdSupply        ID of a promise which is mapped to the corresponding Promise
+     * @param _tokenIdSupply ID of the order (aka VoucherSet) which is mapped to the corresponding Promise.
      * @return                  Address of the holder
      */
     function getSupplyHolder(uint256 _tokenIdSupply)
@@ -1077,7 +1077,7 @@ contract VoucherKernel is IVoucherKernel, Ownable, Pausable, UsingHelpers {
     /**
      * @notice Get promise data not retrieved by other accessor functions
      * @param _promiseKey   ID of the promise
-     * @return cancel or fault period
+     * @return promise data not returned by other accessor methods
      */
     function getPromiseData(bytes32 _promiseKey)
         external

--- a/contracts/VoucherKernel.sol
+++ b/contracts/VoucherKernel.sol
@@ -52,35 +52,31 @@ contract VoucherKernel is IVoucherKernel, Ownable, Pausable, UsingHelpers {
         address addressTokenDeposits;
     }
 
-    address public bosonRouterAddress; //address of the Boson Router contract
-    address public cashierAddress; //address of the Cashier contract
+    address private bosonRouterAddress; //address of the Boson Router contract
+    address private cashierAddress; //address of the Cashier contract
 
-    mapping(bytes32 => Promise) public promises; //promises to deliver goods or services
-    mapping(address => uint256) public tokenNonces; //mapping between seller address and its own nonces. Every time seller creates supply ID it gets incremented. Used to avoid duplicate ID's
-    mapping(uint256 => VoucherPaymentMethod) public paymentDetails; // tokenSupplyId to VoucherPaymentMethod
+    mapping(bytes32 => Promise) private promises; //promises to deliver goods or services
+    mapping(address => uint256) private tokenNonces; //mapping between seller address and its own nonces. Every time seller creates supply ID it gets incremented. Used to avoid duplicate ID's
+    mapping(uint256 => VoucherPaymentMethod) private paymentDetails; // tokenSupplyId to VoucherPaymentMethod
 
-    bytes32[] public promiseKeys;
+    bytes32[] private promiseKeys;
 
-    mapping(uint256 => bytes32) public ordersPromise; //mapping between an order (supply a.k.a. VoucherSet token) and a promise
+    mapping(uint256 => bytes32) private ordersPromise; //mapping between an order (supply a.k.a. VoucherSet token) and a promise
 
-    mapping(uint256 => VoucherStatus) public vouchersStatus; //recording the vouchers evolution
-
-    //standard reqs
-    mapping(uint256 => mapping(address => uint256)) private balances; //balance of token ids of an account
-    mapping(address => mapping(address => bool)) private operatorApprovals; //approval of accounts of an operator
+    mapping(uint256 => VoucherStatus) private vouchersStatus; //recording the vouchers evolution
 
     //ID reqs
-    mapping(uint256 => uint256) public typeCounters; //counter for ID of a particular type of NFT
+    mapping(uint256 => uint256) private typeCounters; //counter for ID of a particular type of NFT
     uint256 public constant MASK_TYPE = uint256(uint128(~0)) << 128; //the type mask in the upper 128 bits
     //1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
 
-    uint256 public constant MASK_NF_INDEX = uint128(~0); //the non-fungible index mask in the lower 128
+    uint256 private constant MASK_NF_INDEX = uint128(~0); //the non-fungible index mask in the lower 128
     //0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000011111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111
 
-    uint256 public constant TYPE_NF_BIT = 1 << 255; //the first bit represents an NFT type
+    uint256 private constant TYPE_NF_BIT = 1 << 255; //the first bit represents an NFT type
     //1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
 
-    uint256 public typeId; //base token type ... 127-bits cover 1.701411835*10^38 types (not differentiating between FTs and NFTs)
+    uint256 private typeId; //base token type ... 127-bits cover 1.701411835*10^38 types (not differentiating between FTs and NFTs)
     /* Token IDs:
     Fungibles: 0, followed by 127-bit FT type ID, in the upper 128 bits, followed by 0 in lower 128-bits
     <0><uint127: base token id><uint128: 0>
@@ -92,8 +88,8 @@ contract VoucherKernel is IVoucherKernel, Ownable, Pausable, UsingHelpers {
     <1><uint127: base token id><uint128: index of non-fungible>
     */
 
-    uint256 public complainPeriod;
-    uint256 public cancelFaultPeriod;
+    uint256 private complainPeriod;
+    uint256 private cancelFaultPeriod;
 
     event LogPromiseCreated(
         bytes32 indexed _promiseId,
@@ -1064,6 +1060,21 @@ contract VoucherKernel is IVoucherKernel, Ownable, Pausable, UsingHelpers {
     }
 
     /**
+     * @notice Get the holder of a supply
+     * @param _tokenIdSupply        ID of a promise which is mapped to the corresponding Promise
+     * @return                  Address of the holder
+     */
+    function getSupplyHolder(uint256 _tokenIdSupply)
+        public
+        view
+        override
+        returns (address)
+    {
+        bytes32 promiseKey = ordersPromise[_tokenIdSupply];
+        return promises[promiseKey].seller;
+    }
+
+    /**
      * @notice Get the current status of a voucher
      * @param _tokenIdVoucher   ID of the voucher token
      * @return                  Status of the voucher (via enum)
@@ -1097,21 +1108,6 @@ contract VoucherKernel is IVoucherKernel, Ownable, Pausable, UsingHelpers {
         returns (address)
     {
         return IERC721(tokensContract).ownerOf(_tokenIdVoucher);
-    }
-
-    /**
-     * @notice Get the holder of a supply
-     * @param _tokenIdSupply        ID of a promise which is mapped to the corresponding Promise
-     * @return                  Address of the holder
-     */
-    function getSupplyHolder(uint256 _tokenIdSupply)
-        public
-        view
-        override
-        returns (address)
-    {
-        bytes32 promiseKey = ordersPromise[_tokenIdSupply];
-        return promises[promiseKey].seller;
     }
 
     /**
@@ -1188,5 +1184,100 @@ contract VoucherKernel is IVoucherKernel, Ownable, Pausable, UsingHelpers {
         return
             !(vouchersStatus[_tokenIdVoucher].isPaymentReleased ||
                 vouchersStatus[_tokenIdVoucher].isDepositsReleased);
+    }
+
+    /**
+     * @notice Get address of the Boson Router to which this contract points
+     * @return Address of the Boson Router contract
+     */
+    function getBosonRouterAddress()
+        external
+        view
+        override
+        returns (address) 
+    {
+        return bosonRouterAddress;
+    }
+
+    /**
+     * @notice Get address of the Cashier contract to which this contract points
+     * @return Address of the Cashier contract
+     */
+    function getCashierAddress()
+        external
+        view
+        override
+        returns (address)
+    {
+        return cashierAddress;
+    }
+
+    /**
+     * @notice Get the token nonce for a seller
+     * @param _seller Address of the seller
+     * @return The seller's nonce
+     */
+    function getTokenNonce(address _seller)
+        external
+        view
+        override
+        returns (uint256) 
+    {
+        return tokenNonces[_seller];
+    }
+
+    /**
+     * @notice Get the current type Id
+     * @return type Id
+     */
+    function getTypeId()
+        external
+        view
+        override
+        returns (uint256)
+    {
+        return typeId;
+    }
+
+    /**
+     * @notice Get the complain period
+     * @return complain period
+     */
+    function getComplainPeriod()
+        external
+        view
+        override
+        returns (uint256)
+    {
+        return complainPeriod;
+    }
+
+    /**
+     * @notice Get the cancel or fault period
+     * @return cancel or fault period
+     */
+    function getCancelFaultPeriod()
+        external
+        view
+        override
+        returns (uint256)
+    {
+        return cancelFaultPeriod;
+    }
+    
+    /**
+     * @notice Get promise data not retrieved by other accessor functions
+     * @param _tokenIdSupply   ID of the supply token
+     * @return cancel or fault period
+     */
+    function getPromiseData(uint256 _tokenIdSupply)
+        external
+        view
+        override
+        returns (bytes32, uint256, uint256, uint256, uint256 )
+    {
+        bytes32 promiseKey = ordersPromise[_tokenIdSupply];
+        Promise memory tPromise = promises[promiseKey];
+        return (tPromise.promiseId, tPromise.nonce, tPromise.validFrom, tPromise.validTo, tPromise.idx); 
     }
 }

--- a/contracts/interfaces/IBosonRouter.sol
+++ b/contracts/interfaces/IBosonRouter.sol
@@ -144,8 +144,5 @@ interface IBosonRouter {
      * @param _party   The address of the seller or buyer
      * @return the specified party's correlcation Id
      */
-    function getCorrelationId(address _party) 
-        external
-        view
-        returns (uint256);
+    function getCorrelationId(address _party) external view returns (uint256);
 }

--- a/contracts/interfaces/IBosonRouter.sol
+++ b/contracts/interfaces/IBosonRouter.sol
@@ -138,4 +138,14 @@ interface IBosonRouter {
      * @param _party   The address of the seller or buyer
      */
     function incrementCorrelationId(address _party) external;
+
+    /**
+     * @notice Return a seller or buyer's correlation Id
+     * @param _party   The address of the seller or buyer
+     * @return the specified party's correlcation Id
+     */
+    function getCorrelationId(address _party) 
+        external
+        view
+        returns (uint256);
 }

--- a/contracts/interfaces/IBosonRouter.sol
+++ b/contracts/interfaces/IBosonRouter.sol
@@ -142,7 +142,7 @@ interface IBosonRouter {
     /**
      * @notice Return a seller or buyer's correlation Id
      * @param _party   The address of the seller or buyer
-     * @return the specified party's correlcation Id
+     * @return the specified party's correlation Id
      */
     function getCorrelationId(address _party) external view returns (uint256);
 }

--- a/contracts/interfaces/IERC1155ERC721.sol
+++ b/contracts/interfaces/IERC1155ERC721.sol
@@ -49,4 +49,10 @@ interface IERC1155ERC721 {
         address indexed _operator,
         bool _approved
     );
+
+    /**
+     * @notice Get the contract owner
+     * @return Address of the owner
+     */
+    function getOwner() external view returns (address);
 }

--- a/contracts/interfaces/IVoucherKernel.sol
+++ b/contracts/interfaces/IVoucherKernel.sol
@@ -288,7 +288,7 @@ interface IVoucherKernel {
 
     /**
      * @notice Get the holder of a supply
-     * @param _tokenIdSupply        ID of a promise which is mapped to the corresponding Promise
+     * @param _tokenIdSupply    _tokenIdSupply ID of the order (aka VoucherSet) which is mapped to the corresponding Promise.
      * @return                  Address of the holder
      */
     function getSupplyHolder(uint256 _tokenIdSupply)
@@ -364,7 +364,7 @@ interface IVoucherKernel {
     /**
      * @notice Get promise data not retrieved by other accessor functions
      * @param _promiseKey   ID of the promise
-     * @return cancel or fault period
+     * @return promise data not returned by other accessor methods
      */
     function getPromiseData(bytes32 _promiseKey)
         external

--- a/contracts/interfaces/IVoucherKernel.sol
+++ b/contracts/interfaces/IVoucherKernel.sol
@@ -281,7 +281,9 @@ interface IVoucherKernel {
         returns (
             uint8,
             bool,
-            bool
+            bool,
+            uint256,
+            uint256
         );
 
     /**
@@ -326,71 +328,52 @@ interface IVoucherKernel {
      * @notice Get address of the Boson Router contract to which this contract points
      * @return Address of the Boson Router contract
      */
-    function getBosonRouterAddress()
-        external
-        view
-        returns (address);
+    function getBosonRouterAddress() external view returns (address);
 
     /**
      * @notice Get address of the Cashier contract to which this contract points
      * @return Address of the Cashier contract
      */
-    function getCashierAddress()
-        external
-        view
-        returns (address);
+    function getCashierAddress() external view returns (address);
 
     /**
      * @notice Get the token nonce for a seller
      * @param _seller Address of the seller
      * @return The seller's
      */
-    function getTokenNonce(address _seller)
-        external
-        view
-        returns (uint256);
+    function getTokenNonce(address _seller) external view returns (uint256);
 
     /**
      * @notice Get the current type Id
      * @return type Id
      */
-    function getTypeId()
-        external
-        view
-        returns (uint256);
+    function getTypeId() external view returns (uint256);
 
     /**
      * @notice Get the complain period
      * @return complain period
      */
-    function getComplainPeriod()
-        external
-        view
-        returns (uint256);
+    function getComplainPeriod() external view returns (uint256);
 
     /**
      * @notice Get the cancel or fault period
      * @return cancel or fault period
      */
-    function getCancelFaultPeriod()
-        external
-        view
-        returns (uint256);
+    function getCancelFaultPeriod() external view returns (uint256);
 
     /**
      * @notice Get promise data not retrieved by other accessor functions
-     * @param _tokenIdSupply   ID of the supply token
+     * @param _promiseKey   ID of the promise
      * @return cancel or fault period
      */
-    function getPromiseData(uint256 _tokenIdSupply)
+    function getPromiseData(bytes32 _promiseKey)
         external
         view
-        returns (bytes32, uint256, uint256, uint256, uint256 );
-    
-    
-    
-
-    
-
-   
+        returns (
+            bytes32,
+            uint256,
+            uint256,
+            uint256,
+            uint256
+        );
 }

--- a/contracts/interfaces/IVoucherKernel.sol
+++ b/contracts/interfaces/IVoucherKernel.sol
@@ -321,4 +321,76 @@ interface IVoucherKernel {
         external
         view
         returns (bool);
+
+    /**
+     * @notice Get address of the Boson Router contract to which this contract points
+     * @return Address of the Boson Router contract
+     */
+    function getBosonRouterAddress()
+        external
+        view
+        returns (address);
+
+    /**
+     * @notice Get address of the Cashier contract to which this contract points
+     * @return Address of the Cashier contract
+     */
+    function getCashierAddress()
+        external
+        view
+        returns (address);
+
+    /**
+     * @notice Get the token nonce for a seller
+     * @param _seller Address of the seller
+     * @return The seller's
+     */
+    function getTokenNonce(address _seller)
+        external
+        view
+        returns (uint256);
+
+    /**
+     * @notice Get the current type Id
+     * @return type Id
+     */
+    function getTypeId()
+        external
+        view
+        returns (uint256);
+
+    /**
+     * @notice Get the complain period
+     * @return complain period
+     */
+    function getComplainPeriod()
+        external
+        view
+        returns (uint256);
+
+    /**
+     * @notice Get the cancel or fault period
+     * @return cancel or fault period
+     */
+    function getCancelFaultPeriod()
+        external
+        view
+        returns (uint256);
+
+    /**
+     * @notice Get promise data not retrieved by other accessor functions
+     * @param _tokenIdSupply   ID of the supply token
+     * @return cancel or fault period
+     */
+    function getPromiseData(uint256 _tokenIdSupply)
+        external
+        view
+        returns (bytes32, uint256, uint256, uint256, uint256 );
+    
+    
+    
+
+    
+
+   
 }

--- a/contracts/mocks/MockBosonRouter.sol
+++ b/contracts/mocks/MockBosonRouter.sol
@@ -165,7 +165,7 @@ contract MockBosonRouter is
 
         IVoucherKernel(voucherKernel).createPaymentMethod(
             tokenIdSupply,
-            ETHETH,
+            5,
             address(0),
             address(0)
         );
@@ -575,10 +575,7 @@ contract MockBosonRouter is
         );
 
         //record funds in escrow ...
-        ICashier(cashierAddress).addEscrowAmount{value: msg.value}(
-            msg.sender
-        );
-
+        ICashier(cashierAddress).addEscrowAmount{value: msg.value}(msg.sender);
     }
 
     function requestVoucherTKNETHWithPermit(
@@ -631,7 +628,7 @@ contract MockBosonRouter is
         );
 
         //record funds in escrow ...
-        ICashier(cashierAddress).addEscrowAmount{value:msg.value}(msg.sender);
+        ICashier(cashierAddress).addEscrowAmount{value: msg.value}(msg.sender);
     }
 
     /**
@@ -697,11 +694,8 @@ contract MockBosonRouter is
      * @notice Increment a seller or buyer's correlation Id
      * @param _party   The address of the seller or buyer
      */
-    function incrementCorrelationId(address _party) 
-        external
-        override
-    {
-         correlationIds[_party]++;
+    function incrementCorrelationId(address _party) external override {
+        correlationIds[_party]++;
     }
 
     /**
@@ -709,10 +703,10 @@ contract MockBosonRouter is
      * @param _party   The address of the seller or buyer
      * @return the specified party's correlcation Id
      */
-    function getCorrelationId(address _party) 
+    function getCorrelationId(address _party)
         external
-        override
         view
+        override
         returns (uint256)
     {
         return correlationIds[_party];

--- a/contracts/mocks/MockBosonRouter.sol
+++ b/contracts/mocks/MockBosonRouter.sol
@@ -27,7 +27,7 @@ contract MockBosonRouter is
     using Address for address payable;
     using SafeMath for uint256;
 
-    mapping(address => uint256) public correlationIds; // whenever a seller or a buyer interacts with the smart contract, a personal txID is emitted from an event.
+    mapping(address => uint256) private correlationIds; // whenever a seller or a buyer interacts with the smart contract, a personal txID is emitted from an event.
 
     using SafeMath for uint256;
 
@@ -165,7 +165,7 @@ contract MockBosonRouter is
 
         IVoucherKernel(voucherKernel).createPaymentMethod(
             tokenIdSupply,
-            5,
+            ETHETH,
             address(0),
             address(0)
         );
@@ -575,7 +575,10 @@ contract MockBosonRouter is
         );
 
         //record funds in escrow ...
-        ICashier(cashierAddress).addEscrowAmount{value: msg.value}(msg.sender);
+        ICashier(cashierAddress).addEscrowAmount{value: msg.value}(
+            msg.sender
+        );
+
     }
 
     function requestVoucherTKNETHWithPermit(
@@ -628,7 +631,7 @@ contract MockBosonRouter is
         );
 
         //record funds in escrow ...
-        ICashier(cashierAddress).addEscrowAmount{value: msg.value}(msg.sender);
+        ICashier(cashierAddress).addEscrowAmount{value:msg.value}(msg.sender);
     }
 
     /**
@@ -690,15 +693,28 @@ contract MockBosonRouter is
         );
     }
 
-    // // // // // // // //
-    // UTILS
-    // // // // // // // //
-
     /**
      * @notice Increment a seller or buyer's correlation Id
      * @param _party   The address of the seller or buyer
      */
-    function incrementCorrelationId(address _party) external override {
-        correlationIds[_party]++;
+    function incrementCorrelationId(address _party) 
+        external
+        override
+    {
+         correlationIds[_party]++;
+    }
+
+    /**
+     * @notice Return a seller or buyer's correlation Id
+     * @param _party   The address of the seller or buyer
+     * @return the specified party's correlcation Id
+     */
+    function getCorrelationId(address _party) 
+        external
+        override
+        view
+        returns (uint256)
+    {
+        return correlationIds[_party];
     }
 }

--- a/test/1_test_fullpath.js
+++ b/test/1_test_fullpath.js
@@ -229,12 +229,20 @@ contract('Voucher tests', async (addresses) => {
       const promiseOrderData = await contractVoucherKernel.getOrderCosts(
         tokenSupplyKey1
       );
-      assert.isTrue(promiseOrderData[constants.PROMISE_ORDER_FIELDS.price].eq(new BN(constants.PROMISE_PRICE1)));
       assert.isTrue(
-        promiseOrderData[constants.PROMISE_ORDER_FIELDS.depositSe].eq(new BN(constants.PROMISE_DEPOSITSE1))
+        promiseOrderData[constants.PROMISE_ORDER_FIELDS.price].eq(
+          new BN(constants.PROMISE_PRICE1)
+        )
       );
       assert.isTrue(
-        promiseOrderData[constants.PROMISE_ORDER_FIELDS.depositBu].eq(new BN(constants.PROMISE_DEPOSITBU1))
+        promiseOrderData[constants.PROMISE_ORDER_FIELDS.depositSe].eq(
+          new BN(constants.PROMISE_DEPOSITSE1)
+        )
+      );
+      assert.isTrue(
+        promiseOrderData[constants.PROMISE_ORDER_FIELDS.depositBu].eq(
+          new BN(constants.PROMISE_DEPOSITBU1)
+        )
       );
 
       const tokenNonce = await contractVoucherKernel.getTokenNonce(
@@ -409,12 +417,20 @@ contract('Voucher tests', async (addresses) => {
       const promiseOrderData = await contractVoucherKernel.getOrderCosts(
         tokenSupplyKey1
       );
-      assert.isTrue(promiseOrderData[constants.PROMISE_ORDER_FIELDS.price].eq(new BN(constants.PROMISE_PRICE1)));
       assert.isTrue(
-        promiseOrderData[constants.PROMISE_ORDER_FIELDS.depositSe].eq(new BN(constants.PROMISE_DEPOSITSE1))
+        promiseOrderData[constants.PROMISE_ORDER_FIELDS.price].eq(
+          new BN(constants.PROMISE_PRICE1)
+        )
       );
       assert.isTrue(
-        promiseOrderData[constants.PROMISE_ORDER_FIELDS.depositBu].eq(new BN(constants.PROMISE_DEPOSITBU1))
+        promiseOrderData[constants.PROMISE_ORDER_FIELDS.depositSe].eq(
+          new BN(constants.PROMISE_DEPOSITSE1)
+        )
+      );
+      assert.isTrue(
+        promiseOrderData[constants.PROMISE_ORDER_FIELDS.depositBu].eq(
+          new BN(constants.PROMISE_DEPOSITBU1)
+        )
       );
 
       const tokenNonce = await contractVoucherKernel.getTokenNonce(
@@ -1498,7 +1514,9 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
       const transaction = await web3.eth.getTransaction(complainTx.tx);
       const transactionBlock = await web3.eth.getBlock(transaction.blockNumber);
       assert.isTrue(
-        voucherStatusBefore[constants.VOUCHER_STATUS_FIELDS.cancelFaultPeriodStart].eq(new BN(transactionBlock.timestamp))
+        voucherStatusBefore[
+          constants.VOUCHER_STATUS_FIELDS.cancelFaultPeriodStart
+        ].eq(new BN(transactionBlock.timestamp))
       );
 
       const cancelTx = await contractBosonRouter.cancelOrFault(
@@ -1528,11 +1546,21 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
       );
 
       //Check it didn't go into a code branch that changes the complainPeriodStart
-      assert.isTrue(voucherStatusAfter[constants.VOUCHER_STATUS_FIELDS.complainPeriodStart].eq(voucherStatusBefore[constants.VOUCHER_STATUS_FIELDS.complainPeriodStart]));
+      assert.isTrue(
+        voucherStatusAfter[
+          constants.VOUCHER_STATUS_FIELDS.complainPeriodStart
+        ].eq(
+          voucherStatusBefore[
+            constants.VOUCHER_STATUS_FIELDS.complainPeriodStart
+          ]
+        )
+      );
 
       // [1010.1100] = hex"AC" = 172 = REFUND_COMPLAIN_COF
       assert.equal(
-        web3.utils.toHex(voucherStatusAfter[constants.VOUCHER_STATUS_FIELDS.status]),
+        web3.utils.toHex(
+          voucherStatusAfter[constants.VOUCHER_STATUS_FIELDS.status]
+        ),
         web3.utils.numberToHex(172),
         'end voucher status not as expected ' +
           '(REFUNDED_COMPLAINED_CANCELORFAULT)'

--- a/test/1_test_fullpath.js
+++ b/test/1_test_fullpath.js
@@ -193,11 +193,28 @@ contract('Voucher tests', async (addresses) => {
       const promiseData = await contractVoucherKernel.getPromiseData(
         promiseId1
       );
-      assert.equal(promiseData[0], promiseId1, 'Promise Id incorrect');
-      assert.isTrue(promiseData[1].eq(constants.ONE), 'Nonce is incorrect');
-      assert.isTrue(promiseData[2].eq(new BN(constants.PROMISE_VALID_FROM)));
-      assert.isTrue(promiseData[3].eq(new BN(constants.PROMISE_VALID_TO)));
-      assert.isTrue(promiseData[4].eq(constants.ZERO));
+      assert.equal(
+        promiseData[constants.PROMISE_DATA_FIELDS.promiseId],
+        promiseId1,
+        'Promise Id incorrect'
+      );
+      assert.isTrue(
+        promiseData[constants.PROMISE_DATA_FIELDS.nonce].eq(constants.ONE),
+        'Nonce is incorrect'
+      );
+      assert.isTrue(
+        promiseData[constants.PROMISE_DATA_FIELDS.validFrom].eq(
+          new BN(constants.PROMISE_VALID_FROM)
+        )
+      );
+      assert.isTrue(
+        promiseData[constants.PROMISE_DATA_FIELDS.validTo].eq(
+          new BN(constants.PROMISE_VALID_TO)
+        )
+      );
+      assert.isTrue(
+        promiseData[constants.PROMISE_DATA_FIELDS.idx].eq(constants.ZERO)
+      );
 
       const promiseSeller = await contractVoucherKernel.getSupplyHolder(
         tokenSupplyKey1
@@ -355,11 +372,29 @@ contract('Voucher tests', async (addresses) => {
       const promiseData = await contractVoucherKernel.getPromiseData(
         promiseId2
       );
-      assert.equal(promiseData[0], promiseId2, 'Promise Id incorrect');
-      assert.isTrue(promiseData[1].eq(new BN(2)), 'Nonce is incorrect');
-      assert.isTrue(promiseData[2].eq(new BN(constants.PROMISE_VALID_FROM)));
-      assert.isTrue(promiseData[3].eq(new BN(constants.PROMISE_VALID_TO)));
-      assert.isTrue(promiseData[4].eq(constants.ONE));
+
+      assert.equal(
+        promiseData[constants.PROMISE_DATA_FIELDS.promiseId],
+        promiseId2,
+        'Promise Id incorrect'
+      );
+      assert.isTrue(
+        promiseData[constants.PROMISE_DATA_FIELDS.nonce].eq(constants.TWO),
+        'Nonce is incorrect'
+      );
+      assert.isTrue(
+        promiseData[constants.PROMISE_DATA_FIELDS.validFrom].eq(
+          new BN(constants.PROMISE_VALID_FROM)
+        )
+      );
+      assert.isTrue(
+        promiseData[constants.PROMISE_DATA_FIELDS.validTo].eq(
+          new BN(constants.PROMISE_VALID_TO)
+        )
+      );
+      assert.isTrue(
+        promiseData[constants.PROMISE_DATA_FIELDS.idx].eq(constants.ONE)
+      );
 
       const promiseSeller = await contractVoucherKernel.getSupplyHolder(
         tokenSupplyKey1
@@ -568,9 +603,17 @@ contract('Voucher tests', async (addresses) => {
       const voucherStatus = await contractVoucherKernel.getVoucherStatus(
         tokenVoucherKey
       );
-      assert.isTrue(voucherStatus[0].eq(new BN(128))); //128 = COMMITTED
-      assert.isFalse(voucherStatus[1], 'Payment released not false');
-      assert.isFalse(voucherStatus[2], 'Deposit released not false');
+      assert.isTrue(
+        voucherStatus[constants.VOUCHER_STATUS_FIELDS.status].eq(new BN(128))
+      ); //128 = COMMITTED
+      assert.isFalse(
+        voucherStatus[constants.VOUCHER_STATUS_FIELDS.isPaymentReleased],
+        'Payment released not false'
+      );
+      assert.isFalse(
+        voucherStatus[constants.VOUCHER_STATUS_FIELDS.isDepositsReleased],
+        'Deposit released not false'
+      );
 
       //Check ERC1155ERC721 state
       const sellerERC1155ERC721Balance = await contractERC1155ERC721.balanceOf(
@@ -667,9 +710,18 @@ contract('Voucher tests', async (addresses) => {
       const voucherStatus = await contractVoucherKernel.getVoucherStatus(
         tokenVoucherKey
       );
-      assert.isTrue(voucherStatus[0].eq(new BN(128))); //128 = COMMITTED
-      assert.isFalse(voucherStatus[1], 'Payment released not false');
-      assert.isFalse(voucherStatus[2], 'Deposit released not false');
+
+      assert.isTrue(
+        voucherStatus[constants.VOUCHER_STATUS_FIELDS.status].eq(new BN(128))
+      ); //128 = COMMITTED
+      assert.isFalse(
+        voucherStatus[constants.VOUCHER_STATUS_FIELDS.isPaymentReleased],
+        'Payment released not false'
+      );
+      assert.isFalse(
+        voucherStatus[constants.VOUCHER_STATUS_FIELDS.isDepositsReleased],
+        'Deposit released not false'
+      );
 
       //Check ERC1155ERC721 state
       const sellerERC1155ERC721Balance = await contractERC1155ERC721.balanceOf(
@@ -900,11 +952,17 @@ contract('Voucher tests', async (addresses) => {
       const voucherStatus = await contractVoucherKernel.getVoucherStatus(
         tokenVoucherKey1
       );
-      assert.isTrue(voucherStatus[0].eq(new BN(192)));
+      assert.isTrue(
+        voucherStatus[constants.VOUCHER_STATUS_FIELDS.status].eq(new BN(192))
+      );
 
       const transaction = await web3.eth.getTransaction(txRedeem.tx);
       const transactionBlock = await web3.eth.getBlock(transaction.blockNumber);
-      assert.isTrue(voucherStatus[3].eq(new BN(transactionBlock.timestamp)));
+      assert.isTrue(
+        voucherStatus[constants.VOUCHER_STATUS_FIELDS.complainPeriodStart].eq(
+          new BN(transactionBlock.timestamp)
+        )
+      );
     });
 
     it('mark non-redeemed voucher as expired', async () => {
@@ -944,7 +1002,7 @@ contract('Voucher tests', async (addresses) => {
 
       //[1001.0000] = hex"90" = 144 = EXPIRED
       assert.equal(
-        web3.utils.toHex(voucherStatus[0]),
+        web3.utils.toHex(voucherStatus[constants.VOUCHER_STATUS_FIELDS.status]),
         web3.utils.numberToHex(144),
         'end voucher status not as expected (EXPIRED)'
       );
@@ -978,7 +1036,9 @@ contract('Voucher tests', async (addresses) => {
       const voucherStatus = await contractVoucherKernel.getVoucherStatus(
         tokenVoucherKey1
       );
-      assert.isTrue(voucherStatus[0].eq(new BN(194)));
+      assert.isTrue(
+        voucherStatus[constants.VOUCHER_STATUS_FIELDS.status].eq(new BN(194))
+      );
     });
 
     it('must fail: unauthorized redemption', async () => {
@@ -1136,7 +1196,10 @@ contract('Voucher tests', async (addresses) => {
       const voucherStatus = await contractVoucherKernel.getVoucherStatus(
         tokenVoucherKey1
       );
-      assert.isTrue(voucherStatus[1], 'Payment not released');
+      assert.isTrue(
+        voucherStatus[constants.VOUCHER_STATUS_FIELDS.isPaymentReleased],
+        'Payment not released'
+      );
 
       //Check seller account balance
       const sellerBalanceAfter = new BN(
@@ -1364,11 +1427,15 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
       );
       const transaction = await web3.eth.getTransaction(txRefund.tx);
       const transactionBlock = await web3.eth.getBlock(transaction.blockNumber);
-      assert.isTrue(voucherStatus[3].eq(new BN(transactionBlock.timestamp)));
+      assert.isTrue(
+        voucherStatus[constants.VOUCHER_STATUS_FIELDS.complainPeriodStart].eq(
+          new BN(transactionBlock.timestamp)
+        )
+      );
 
       // [1010.0000] = hex"A0" = 160 = REFUND
       assert.equal(
-        web3.utils.toHex(voucherStatus[0]),
+        web3.utils.toHex(voucherStatus[constants.VOUCHER_STATUS_FIELDS.status]),
         web3.utils.numberToHex(160),
         'end voucher status not as expected (REFUNDED)'
       );
@@ -1402,11 +1469,15 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
       );
       const transaction = await web3.eth.getTransaction(complainTx.tx);
       const transactionBlock = await web3.eth.getBlock(transaction.blockNumber);
-      assert.isTrue(voucherStatus[4].eq(new BN(transactionBlock.timestamp)));
+      assert.isTrue(
+        voucherStatus[
+          constants.VOUCHER_STATUS_FIELDS.cancelFaultPeriodStart
+        ].eq(new BN(transactionBlock.timestamp))
+      );
 
       // [1010.1000] = hex"A8" = 168 = REFUND_COMPLAIN
       assert.equal(
-        web3.utils.toHex(voucherStatus[0]),
+        web3.utils.toHex(voucherStatus[constants.VOUCHER_STATUS_FIELDS.status]),
         web3.utils.numberToHex(168),
         'end voucher status not as expected (REFUNDED_COMPLAINED)'
       );
@@ -1494,7 +1565,7 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
 
       // [1000.0100] = hex"84" = 132 = CANCELORFAULT
       assert.equal(
-        web3.utils.toHex(voucherStatus[0]),
+        web3.utils.toHex(voucherStatus[constants.VOUCHER_STATUS_FIELDS.status]),
         web3.utils.numberToHex(132),
         'end voucher status not as expected (CANCELORFAULT)'
       );

--- a/test/1_test_fullpath.js
+++ b/test/1_test_fullpath.js
@@ -229,12 +229,12 @@ contract('Voucher tests', async (addresses) => {
       const promiseOrderData = await contractVoucherKernel.getOrderCosts(
         tokenSupplyKey1
       );
-      assert.isTrue(promiseOrderData[0].eq(new BN(constants.PROMISE_PRICE1)));
+      assert.isTrue(promiseOrderData[constants.PROMISE_ORDER_FIELDS.price].eq(new BN(constants.PROMISE_PRICE1)));
       assert.isTrue(
-        promiseOrderData[1].eq(new BN(constants.PROMISE_DEPOSITSE1))
+        promiseOrderData[constants.PROMISE_ORDER_FIELDS.depositSe].eq(new BN(constants.PROMISE_DEPOSITSE1))
       );
       assert.isTrue(
-        promiseOrderData[2].eq(new BN(constants.PROMISE_DEPOSITBU1))
+        promiseOrderData[constants.PROMISE_ORDER_FIELDS.depositBu].eq(new BN(constants.PROMISE_DEPOSITBU1))
       );
 
       const tokenNonce = await contractVoucherKernel.getTokenNonce(
@@ -331,7 +331,7 @@ contract('Voucher tests', async (addresses) => {
           promiseId2 = ev._promiseId;
           return (
             ev._promiseId > 0 &&
-            ev._nonce.eq(new BN(2)) &&
+            ev._nonce.eq(constants.TWO) &&
             ev._seller === users.seller.address &&
             ev._validFrom.eq(new BN(constants.PROMISE_VALID_FROM)) &&
             ev._validTo.eq(new BN(constants.PROMISE_VALID_TO)) &&
@@ -409,18 +409,18 @@ contract('Voucher tests', async (addresses) => {
       const promiseOrderData = await contractVoucherKernel.getOrderCosts(
         tokenSupplyKey1
       );
-      assert.isTrue(promiseOrderData[0].eq(new BN(constants.PROMISE_PRICE1)));
+      assert.isTrue(promiseOrderData[constants.PROMISE_ORDER_FIELDS.price].eq(new BN(constants.PROMISE_PRICE1)));
       assert.isTrue(
-        promiseOrderData[1].eq(new BN(constants.PROMISE_DEPOSITSE1))
+        promiseOrderData[constants.PROMISE_ORDER_FIELDS.depositSe].eq(new BN(constants.PROMISE_DEPOSITSE1))
       );
       assert.isTrue(
-        promiseOrderData[2].eq(new BN(constants.PROMISE_DEPOSITBU1))
+        promiseOrderData[constants.PROMISE_ORDER_FIELDS.depositBu].eq(new BN(constants.PROMISE_DEPOSITBU1))
       );
 
       const tokenNonce = await contractVoucherKernel.getTokenNonce(
         users.seller.address
       );
-      assert.isTrue(tokenNonce.eq(new BN(2)));
+      assert.isTrue(tokenNonce.eq(constants.TWO));
 
       //Check ERC1155ERC721 state
       const sellerERC1155ERC721BalanceVoucherSet1 = await contractERC1155ERC721.balanceOf(
@@ -972,7 +972,7 @@ contract('Voucher tests', async (addresses) => {
 
       // [1000.0000] = hex"80" = 128 = COMMITTED
       assert.equal(
-        web3.utils.toHex(statusBefore[0]),
+        web3.utils.toHex(statusBefore[constants.VOUCHER_STATUS_FIELDS.status]),
         web3.utils.numberToHex(128),
         'initial voucher status not as expected (COMMITTED)'
       );
@@ -1498,7 +1498,7 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
       const transaction = await web3.eth.getTransaction(complainTx.tx);
       const transactionBlock = await web3.eth.getBlock(transaction.blockNumber);
       assert.isTrue(
-        voucherStatusBefore[4].eq(new BN(transactionBlock.timestamp))
+        voucherStatusBefore[constants.VOUCHER_STATUS_FIELDS.cancelFaultPeriodStart].eq(new BN(transactionBlock.timestamp))
       );
 
       const cancelTx = await contractBosonRouter.cancelOrFault(
@@ -1528,11 +1528,11 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
       );
 
       //Check it didn't go into a code branch that changes the complainPeriodStart
-      assert.isTrue(voucherStatusAfter[3].eq(voucherStatusBefore[3]));
+      assert.isTrue(voucherStatusAfter[constants.VOUCHER_STATUS_FIELDS.complainPeriodStart].eq(voucherStatusBefore[constants.VOUCHER_STATUS_FIELDS.complainPeriodStart]));
 
       // [1010.1100] = hex"AC" = 172 = REFUND_COMPLAIN_COF
       assert.equal(
-        web3.utils.toHex(voucherStatusAfter[0]),
+        web3.utils.toHex(voucherStatusAfter[constants.VOUCHER_STATUS_FIELDS.status]),
         web3.utils.numberToHex(172),
         'end voucher status not as expected ' +
           '(REFUNDED_COMPLAINED_CANCELORFAULT)'
@@ -1599,7 +1599,7 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
 
       // [1001.0000] = hex"90" = 144 = EXPIRED
       assert.equal(
-        web3.utils.toHex(statusAfter[0]),
+        web3.utils.toHex(statusAfter[constants.VOUCHER_STATUS_FIELDS.status]),
         web3.utils.numberToHex(144),
         'end voucher status not as expected (EXPIRED)'
       );
@@ -1627,7 +1627,7 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
 
       // [1001.1000] = hex"98" = 152 = EXPIRED_COMPLAIN
       assert.equal(
-        web3.utils.toHex(statusAfter[0]),
+        web3.utils.toHex(statusAfter[constants.VOUCHER_STATUS_FIELDS.status]),
         web3.utils.numberToHex(152),
         'end voucher status not as expected (EXPIRED_COMPLAINED)'
       );
@@ -1660,7 +1660,7 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
 
       // [1001.1000] = hex"9C" = 156 = EXPIRED_COMPLAINED_CANCELORFAULT
       assert.equal(
-        web3.utils.toHex(statusAfter[0]),
+        web3.utils.toHex(statusAfter[constants.VOUCHER_STATUS_FIELDS.status]),
         web3.utils.numberToHex(156),
         'end voucher status not as expected ' +
           '(EXPIRED_COMPLAINED_CANCELORFAULT)'

--- a/test/1_test_fullpath.js
+++ b/test/1_test_fullpath.js
@@ -16,7 +16,7 @@ const FundLimitsOracle = artifacts.require('FundLimitsOracle');
 const MockBosonRouter = artifacts.require('MockBosonRouter');
 const BN = web3.utils.BN;
 
-contract.only('Voucher tests', async (addresses) => {
+contract('Voucher tests', async (addresses) => {
   const users = new Users(addresses);
 
   let contractERC1155ERC721,
@@ -190,33 +190,37 @@ contract.only('Voucher tests', async (addresses) => {
       );
 
       //Check VocherKernel State
-      /*
-      const promise = await contractVoucherKernel.promises(promiseId1);
-      assert.equal(promise.promiseId, promiseId1, 'Promise Id incorrect');
-      assert.isTrue(promise.nonce.eq(constants.ONE), 'Nonce is incorrect');
+      const promiseData = await contractVoucherKernel.getPromiseData(
+        promiseId1
+      );
+      assert.equal(promiseData[0], promiseId1, 'Promise Id incorrect');
+      assert.isTrue(promiseData[1].eq(constants.ONE), 'Nonce is incorrect');
+      assert.isTrue(promiseData[2].eq(new BN(constants.PROMISE_VALID_FROM)));
+      assert.isTrue(promiseData[3].eq(new BN(constants.PROMISE_VALID_TO)));
+      assert.isTrue(promiseData[4].eq(constants.ZERO));
+
+      const promiseSeller = await contractVoucherKernel.getSupplyHolder(
+        tokenSupplyKey1
+      );
+
       assert.strictEqual(
-        promise.seller,
+        promiseSeller,
         users.seller.address,
         'Seller incorrect'
       );
-      */
-      assert.isTrue(promise.validFrom.eq(new BN(constants.PROMISE_VALID_FROM)));
-      assert.isTrue(promise.validTo.eq(new BN(constants.PROMISE_VALID_TO)));
-      assert.isTrue(promise.price.eq(new BN(constants.PROMISE_PRICE1)));
-      assert.isTrue(promise.depositSe.eq(new BN(constants.PROMISE_DEPOSITSE1)));
-      assert.isTrue(promise.depositBu.eq(new BN(constants.PROMISE_DEPOSITBU1)));
-      assert.isTrue(promise.idx.eq(constants.ZERO));
 
-      const orderPromiseId = await contractVoucherKernel.ordersPromise(
+      const promiseOrderData = await contractVoucherKernel.getOrderCosts(
         tokenSupplyKey1
       );
-      assert.strictEqual(
-        orderPromiseId,
-        promiseId1,
-        'Order Promise Id incorrect'
+      assert.isTrue(promiseOrderData[0].eq(new BN(constants.PROMISE_PRICE1)));
+      assert.isTrue(
+        promiseOrderData[1].eq(new BN(constants.PROMISE_DEPOSITSE1))
+      );
+      assert.isTrue(
+        promiseOrderData[2].eq(new BN(constants.PROMISE_DEPOSITBU1))
       );
 
-      const tokenNonce = await contractVoucherKernel.tokenNonces(
+      const tokenNonce = await contractVoucherKernel.getTokenNonce(
         users.seller.address
       );
       assert.isTrue(tokenNonce.eq(constants.ONE));
@@ -348,31 +352,37 @@ contract.only('Voucher tests', async (addresses) => {
       );
 
       //Check VocherKernel State
-      const promise = await contractVoucherKernel.promises(promiseId2);
-      assert.strictEqual(promise.promiseId, promiseId2, 'Promise Id incorrect');
-      assert.isTrue(promise.nonce.eq(new BN(2)));
+      const promiseData = await contractVoucherKernel.getPromiseData(
+        promiseId2
+      );
+      assert.equal(promiseData[0], promiseId2, 'Promise Id incorrect');
+      assert.isTrue(promiseData[1].eq(new BN(2)), 'Nonce is incorrect');
+      assert.isTrue(promiseData[2].eq(new BN(constants.PROMISE_VALID_FROM)));
+      assert.isTrue(promiseData[3].eq(new BN(constants.PROMISE_VALID_TO)));
+      assert.isTrue(promiseData[4].eq(constants.ONE));
+
+      const promiseSeller = await contractVoucherKernel.getSupplyHolder(
+        tokenSupplyKey1
+      );
+
       assert.strictEqual(
-        promise.seller,
+        promiseSeller,
         users.seller.address,
         'Seller incorrect'
       );
-      assert.isTrue(promise.validFrom.eq(new BN(constants.PROMISE_VALID_FROM)));
-      assert.isTrue(promise.validTo.eq(new BN(constants.PROMISE_VALID_TO)));
-      assert.isTrue(promise.price.eq(new BN(constants.PROMISE_PRICE2)));
-      assert.isTrue(promise.depositSe.eq(new BN(constants.PROMISE_DEPOSITSE2)));
-      assert.isTrue(promise.depositBu.eq(new BN(constants.PROMISE_DEPOSITBU2)));
-      assert.isTrue(promise.idx.eq(constants.ONE));
 
-      const orderPromiseId = await contractVoucherKernel.ordersPromise(
-        tokenSupplyKey2
+      const promiseOrderData = await contractVoucherKernel.getOrderCosts(
+        tokenSupplyKey1
       );
-      assert.strictEqual(
-        orderPromiseId,
-        promiseId2,
-        'Order Promise Id incorrect'
+      assert.isTrue(promiseOrderData[0].eq(new BN(constants.PROMISE_PRICE1)));
+      assert.isTrue(
+        promiseOrderData[1].eq(new BN(constants.PROMISE_DEPOSITSE1))
+      );
+      assert.isTrue(
+        promiseOrderData[2].eq(new BN(constants.PROMISE_DEPOSITBU1))
       );
 
-      const tokenNonce = await contractVoucherKernel.tokenNonces(
+      const tokenNonce = await contractVoucherKernel.getTokenNonce(
         users.seller.address
       );
       assert.isTrue(tokenNonce.eq(new BN(2)));
@@ -555,18 +565,12 @@ contract.only('Voucher tests', async (addresses) => {
       );
 
       //Check Voucher Kernel state
-      const voucherStatus = await contractVoucherKernel.vouchersStatus(
+      const voucherStatus = await contractVoucherKernel.getVoucherStatus(
         tokenVoucherKey
       );
-      assert.isTrue(voucherStatus.status.eq(new BN(128))); //128 = COMMITTED
-      assert.isFalse(
-        voucherStatus.isPaymentReleased,
-        'Payment released not false'
-      );
-      assert.isFalse(
-        voucherStatus.isDepositsReleased,
-        'Deposit released not false'
-      );
+      assert.isTrue(voucherStatus[0].eq(new BN(128))); //128 = COMMITTED
+      assert.isFalse(voucherStatus[1], 'Payment released not false');
+      assert.isFalse(voucherStatus[2], 'Deposit released not false');
 
       //Check ERC1155ERC721 state
       const sellerERC1155ERC721Balance = await contractERC1155ERC721.balanceOf(
@@ -660,18 +664,12 @@ contract.only('Voucher tests', async (addresses) => {
       );
 
       //Check Voucher Kernel state
-      const voucherStatus = await contractVoucherKernel.vouchersStatus(
+      const voucherStatus = await contractVoucherKernel.getVoucherStatus(
         tokenVoucherKey
       );
-      assert.isTrue(voucherStatus.status.eq(new BN(128))); //128 = COMMITTED
-      assert.isFalse(
-        voucherStatus.isPaymentReleased,
-        'Payment released not false'
-      );
-      assert.isFalse(
-        voucherStatus.isDepositsReleased,
-        'Deposit released not false'
-      );
+      assert.isTrue(voucherStatus[0].eq(new BN(128))); //128 = COMMITTED
+      assert.isFalse(voucherStatus[1], 'Payment released not false');
+      assert.isFalse(voucherStatus[2], 'Deposit released not false');
 
       //Check ERC1155ERC721 state
       const sellerERC1155ERC721Balance = await contractERC1155ERC721.balanceOf(
@@ -902,13 +900,11 @@ contract.only('Voucher tests', async (addresses) => {
       const voucherStatus = await contractVoucherKernel.getVoucherStatus(
         tokenVoucherKey1
       );
-      assert.isTrue(voucherStatus.status.eq(new BN(192)));
+      assert.isTrue(voucherStatus[0].eq(new BN(192)));
 
       const transaction = await web3.eth.getTransaction(txRedeem.tx);
       const transactionBlock = await web3.eth.getBlock(transaction.blockNumber);
-      assert.isTrue(
-        voucherStatus.complainPeriodStart.eq(new BN(transactionBlock.timestamp))
-      );
+      assert.isTrue(voucherStatus[3].eq(new BN(transactionBlock.timestamp)));
     });
 
     it('mark non-redeemed voucher as expired', async () => {
@@ -918,7 +914,7 @@ contract.only('Voucher tests', async (addresses) => {
 
       // [1000.0000] = hex"80" = 128 = COMMITTED
       assert.equal(
-        web3.utils.toHex(statusBefore.status),
+        web3.utils.toHex(statusBefore[0]),
         web3.utils.numberToHex(128),
         'initial voucher status not as expected (COMMITTED)'
       );
@@ -942,13 +938,13 @@ contract.only('Voucher tests', async (addresses) => {
       );
 
       //Check VoucherKernel state
-      const voucherStatus = await contractVoucherKernel.vouchersStatus(
+      const voucherStatus = await contractVoucherKernel.getVoucherStatus(
         tokenVoucherKey2
       );
 
       //[1001.0000] = hex"90" = 144 = EXPIRED
       assert.equal(
-        web3.utils.toHex(voucherStatus.status),
+        web3.utils.toHex(voucherStatus[0]),
         web3.utils.numberToHex(144),
         'end voucher status not as expected (EXPIRED)'
       );
@@ -982,7 +978,7 @@ contract.only('Voucher tests', async (addresses) => {
       const voucherStatus = await contractVoucherKernel.getVoucherStatus(
         tokenVoucherKey1
       );
-      assert.isTrue(voucherStatus.status.eq(new BN(194)));
+      assert.isTrue(voucherStatus[0].eq(new BN(194)));
     });
 
     it('must fail: unauthorized redemption', async () => {
@@ -1140,7 +1136,7 @@ contract.only('Voucher tests', async (addresses) => {
       const voucherStatus = await contractVoucherKernel.getVoucherStatus(
         tokenVoucherKey1
       );
-      assert.isTrue(voucherStatus.isPaymentReleased, 'Payment not released');
+      assert.isTrue(voucherStatus[1], 'Payment not released');
 
       //Check seller account balance
       const sellerBalanceAfter = new BN(
@@ -1285,7 +1281,7 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
       );
 
       //Check VoucherKernel state
-      const newComplainePeriod = await contractVoucherKernel.complainPeriod();
+      const newComplainePeriod = await contractVoucherKernel.getComplainPeriod();
       assert.isTrue(newComplainePeriod.eq(new BN(complainPeriodSeconds)));
     });
 
@@ -1324,7 +1320,7 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
       );
 
       //Check VoucherKernel state
-      const newCancelOrFaultPeriod = await contractVoucherKernel.cancelFaultPeriod();
+      const newCancelOrFaultPeriod = await contractVoucherKernel.getCancelFaultPeriod();
       assert.isTrue(
         newCancelOrFaultPeriod.eq(new BN(cancelFaultPeriodSeconds))
       );
@@ -1363,18 +1359,16 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
       );
 
       //Check VoucherKernel state
-      const voucherStatus = await contractVoucherKernel.vouchersStatus(
+      const voucherStatus = await contractVoucherKernel.getVoucherStatus(
         tokenVoucherKey1
       );
       const transaction = await web3.eth.getTransaction(txRefund.tx);
       const transactionBlock = await web3.eth.getBlock(transaction.blockNumber);
-      assert.isTrue(
-        voucherStatus.complainPeriodStart.eq(new BN(transactionBlock.timestamp))
-      );
+      assert.isTrue(voucherStatus[3].eq(new BN(transactionBlock.timestamp)));
 
       // [1010.0000] = hex"A0" = 160 = REFUND
       assert.equal(
-        web3.utils.toHex(voucherStatus.status),
+        web3.utils.toHex(voucherStatus[0]),
         web3.utils.numberToHex(160),
         'end voucher status not as expected (REFUNDED)'
       );
@@ -1403,20 +1397,16 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
       );
 
       //Check VoucherKernel state
-      const voucherStatus = await contractVoucherKernel.vouchersStatus(
+      const voucherStatus = await contractVoucherKernel.getVoucherStatus(
         tokenVoucherKey1
       );
       const transaction = await web3.eth.getTransaction(complainTx.tx);
       const transactionBlock = await web3.eth.getBlock(transaction.blockNumber);
-      assert.isTrue(
-        voucherStatus.cancelFaultPeriodStart.eq(
-          new BN(transactionBlock.timestamp)
-        )
-      );
+      assert.isTrue(voucherStatus[4].eq(new BN(transactionBlock.timestamp)));
 
       // [1010.1000] = hex"A8" = 168 = REFUND_COMPLAIN
       assert.equal(
-        web3.utils.toHex(voucherStatus.status),
+        web3.utils.toHex(voucherStatus[0]),
         web3.utils.numberToHex(168),
         'end voucher status not as expected (REFUNDED_COMPLAINED)'
       );
@@ -1431,15 +1421,13 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
       });
 
       //Check VoucherKernel state
-      const voucherStatusBefore = await contractVoucherKernel.vouchersStatus(
+      const voucherStatusBefore = await contractVoucherKernel.getVoucherStatus(
         tokenVoucherKey1
       );
       const transaction = await web3.eth.getTransaction(complainTx.tx);
       const transactionBlock = await web3.eth.getBlock(transaction.blockNumber);
       assert.isTrue(
-        voucherStatusBefore.cancelFaultPeriodStart.eq(
-          new BN(transactionBlock.timestamp)
-        )
+        voucherStatusBefore[4].eq(new BN(transactionBlock.timestamp))
       );
 
       const cancelTx = await contractBosonRouter.cancelOrFault(
@@ -1464,20 +1452,16 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
       );
 
       //Check VoucherKernel state
-      const voucherStatusAfter = await contractVoucherKernel.vouchersStatus(
+      const voucherStatusAfter = await contractVoucherKernel.getVoucherStatus(
         tokenVoucherKey1
       );
 
       //Check it didn't go into a code branch that changes the complainPeriodStart
-      assert.isTrue(
-        voucherStatusAfter.complainPeriodStart.eq(
-          voucherStatusBefore.complainPeriodStart
-        )
-      );
+      assert.isTrue(voucherStatusAfter[3].eq(voucherStatusBefore[3]));
 
       // [1010.1100] = hex"AC" = 172 = REFUND_COMPLAIN_COF
       assert.equal(
-        web3.utils.toHex(voucherStatusAfter.status),
+        web3.utils.toHex(voucherStatusAfter[0]),
         web3.utils.numberToHex(172),
         'end voucher status not as expected ' +
           '(REFUNDED_COMPLAINED_CANCELORFAULT)'
@@ -1504,13 +1488,13 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
         from: users.seller.address,
       });
 
-      const voucherStatus = await contractVoucherKernel.vouchersStatus(
+      const voucherStatus = await contractVoucherKernel.getVoucherStatus(
         tokenVoucherKey1
       );
 
       // [1000.0100] = hex"84" = 132 = CANCELORFAULT
       assert.equal(
-        web3.utils.toHex(voucherStatus.status),
+        web3.utils.toHex(voucherStatus[0]),
         web3.utils.numberToHex(132),
         'end voucher status not as expected (CANCELORFAULT)'
       );
@@ -1538,13 +1522,13 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
 
       await contractVoucherKernel.triggerExpiration(tokenVoucherKey1);
 
-      let statusAfter = await contractVoucherKernel.vouchersStatus(
+      let statusAfter = await contractVoucherKernel.getVoucherStatus(
         tokenVoucherKey1
       );
 
       // [1001.0000] = hex"90" = 144 = EXPIRED
       assert.equal(
-        web3.utils.toHex(statusAfter.status),
+        web3.utils.toHex(statusAfter[0]),
         web3.utils.numberToHex(144),
         'end voucher status not as expected (EXPIRED)'
       );
@@ -1566,7 +1550,7 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
         'complain not successful'
       );
 
-      statusAfter = await contractVoucherKernel.vouchersStatus(
+      statusAfter = await contractVoucherKernel.getVoucherStatus(
         tokenVoucherKey1
       );
 
@@ -1599,7 +1583,7 @@ contract('Voucher tests - UNHAPPY PATH', async (addresses) => {
         'complain not successful'
       );
 
-      statusAfter = await contractVoucherKernel.vouchersStatus(
+      statusAfter = await contractVoucherKernel.getVoucherStatus(
         tokenVoucherKey1
       );
 

--- a/test/1_test_fullpath.js
+++ b/test/1_test_fullpath.js
@@ -16,7 +16,7 @@ const FundLimitsOracle = artifacts.require('FundLimitsOracle');
 const MockBosonRouter = artifacts.require('MockBosonRouter');
 const BN = web3.utils.BN;
 
-contract('Voucher tests', async (addresses) => {
+contract.only('Voucher tests', async (addresses) => {
   const users = new Users(addresses);
 
   let contractERC1155ERC721,
@@ -184,12 +184,13 @@ contract('Voucher tests', async (addresses) => {
 
       //Check BosonRouter state
       assert.equal(
-        await contractBosonRouter.correlationIds(users.seller.address),
+        await contractBosonRouter.getCorrelationId(users.seller.address),
         1,
         'Correlation Id incorrect'
       );
 
       //Check VocherKernel State
+      /*
       const promise = await contractVoucherKernel.promises(promiseId1);
       assert.equal(promise.promiseId, promiseId1, 'Promise Id incorrect');
       assert.isTrue(promise.nonce.eq(constants.ONE), 'Nonce is incorrect');
@@ -198,6 +199,7 @@ contract('Voucher tests', async (addresses) => {
         users.seller.address,
         'Seller incorrect'
       );
+      */
       assert.isTrue(promise.validFrom.eq(new BN(constants.PROMISE_VALID_FROM)));
       assert.isTrue(promise.validTo.eq(new BN(constants.PROMISE_VALID_TO)));
       assert.isTrue(promise.price.eq(new BN(constants.PROMISE_PRICE1)));
@@ -340,7 +342,7 @@ contract('Voucher tests', async (addresses) => {
 
       //Check BosonRouter state
       assert.equal(
-        await contractBosonRouter.correlationIds(users.seller.address),
+        await contractBosonRouter.getCorrelationId(users.seller.address),
         2,
         'Correlation Id incorrect'
       );
@@ -547,7 +549,7 @@ contract('Voucher tests', async (addresses) => {
 
       //Check BosonRouter state
       assert.equal(
-        await contractBosonRouter.correlationIds(users.buyer.address),
+        await contractBosonRouter.getCorrelationId(users.buyer.address),
         1,
         'Correlation Id incorrect'
       );
@@ -652,7 +654,7 @@ contract('Voucher tests', async (addresses) => {
 
       //Check BosonRouter state
       assert.equal(
-        await contractBosonRouter.correlationIds(users.buyer.address),
+        await contractBosonRouter.getCorrelationId(users.buyer.address),
         1,
         'Correlation Id incorrect'
       );
@@ -897,7 +899,7 @@ contract('Voucher tests', async (addresses) => {
       );
 
       //Check VoucherKernel state
-      const voucherStatus = await contractVoucherKernel.vouchersStatus(
+      const voucherStatus = await contractVoucherKernel.getVoucherStatus(
         tokenVoucherKey1
       );
       assert.isTrue(voucherStatus.status.eq(new BN(192)));
@@ -910,7 +912,7 @@ contract('Voucher tests', async (addresses) => {
     });
 
     it('mark non-redeemed voucher as expired', async () => {
-      const statusBefore = await contractVoucherKernel.vouchersStatus(
+      const statusBefore = await contractVoucherKernel.getVoucherStatus(
         tokenVoucherKey2
       );
 
@@ -977,7 +979,7 @@ contract('Voucher tests', async (addresses) => {
       );
 
       //Check VoucherKernel state
-      const voucherStatus = await contractVoucherKernel.vouchersStatus(
+      const voucherStatus = await contractVoucherKernel.getVoucherStatus(
         tokenVoucherKey1
       );
       assert.isTrue(voucherStatus.status.eq(new BN(194)));
@@ -1135,7 +1137,7 @@ contract('Voucher tests', async (addresses) => {
       buyerEscrowedAfter.gt(buyerEscrowedBefore);
 
       //Check VoucherKernel state
-      const voucherStatus = await contractVoucherKernel.vouchersStatus(
+      const voucherStatus = await contractVoucherKernel.getVoucherStatus(
         tokenVoucherKey1
       );
       assert.isTrue(voucherStatus.isPaymentReleased, 'Payment not released');

--- a/test/2_test_fullpath_with_permit.js
+++ b/test/2_test_fullpath_with_permit.js
@@ -139,7 +139,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
 
         timestamp = await Utils.getCurrTimestamp();
 
-        const correlationId = await contractBosonRouter.correlationIds(
+        const correlationId = await contractBosonRouter.getCorrelationId(
           users.seller.address
         );
         assert.equal(
@@ -171,7 +171,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
       });
 
       it('Seller correlationId should be incremented after order is created', async () => {
-        const correlationId = await contractBosonRouter.correlationIds(
+        const correlationId = await contractBosonRouter.getCorrelationId(
           users.seller.address
         );
 
@@ -247,22 +247,30 @@ contract('Cashier and VoucherKernel', async (addresses) => {
           constants.QTY_10
         );
 
-        const paymentDetails = await contractVoucherKernel.paymentDetails(
+        const paymentMethod = await contractVoucherKernel.getVoucherPaymentMethod(
+          tokenSupplyKey
+        );
+
+        const addressTokenPrice = await contractVoucherKernel.getVoucherPriceToken(
+          tokenSupplyKey
+        );
+
+        const addressTokenDeposits = await contractVoucherKernel.getVoucherDepositToken(
           tokenSupplyKey
         );
 
         assert.equal(
-          paymentDetails.paymentMethod.toString(),
+          paymentMethod.toString(),
           paymentMethods.ETHETH,
           'Payment Method ETHETH not set correctly'
         );
         assert.equal(
-          paymentDetails.addressTokenPrice.toString(),
+          addressTokenPrice.toString(),
           constants.ZERO_ADDRESS,
           'ETHETH Method Price Token Address mismatch'
         );
         assert.equal(
-          paymentDetails.addressTokenDeposits.toString(),
+          addressTokenDeposits.toString(),
           constants.ZERO_ADDRESS,
           'ETHETH Method Deposit Token Address mismatch'
         );
@@ -386,7 +394,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
             tokensToMint
           );
 
-          const correlationId = await contractBosonRouter.correlationIds(
+          const correlationId = await contractBosonRouter.getCorrelationId(
             users.seller.address
           );
           assert.equal(
@@ -419,7 +427,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
         });
 
         it('Seller correlationId should be incremented after order is created', async () => {
-          const correlationId = await contractBosonRouter.correlationIds(
+          const correlationId = await contractBosonRouter.getCorrelationId(
             users.seller.address
           );
 
@@ -494,22 +502,30 @@ contract('Cashier and VoucherKernel', async (addresses) => {
             constants.QTY_10
           );
 
-          const paymentDetails = await contractVoucherKernel.paymentDetails(
+          const paymentMethod = await contractVoucherKernel.getVoucherPaymentMethod(
+            tokenSupplyKey
+          );
+
+          const addressTokenPrice = await contractVoucherKernel.getVoucherPriceToken(
+            tokenSupplyKey
+          );
+
+          const addressTokenDeposits = await contractVoucherKernel.getVoucherDepositToken(
             tokenSupplyKey
           );
 
           assert.equal(
-            paymentDetails.paymentMethod.toString(),
+            paymentMethod.toString(),
             paymentMethods.ETHTKN,
             'Payment Method ETHTKN not set correctly'
           );
           assert.equal(
-            paymentDetails.addressTokenPrice.toString(),
+            addressTokenPrice.toString(),
             constants.ZERO_ADDRESS,
             'ETHTKN Method Price Token Address mismatch'
           );
           assert.equal(
-            paymentDetails.addressTokenDeposits.toString(),
+            addressTokenDeposits.toString(),
             contractBSNTokenDeposit.address,
             'ETHTKN Method Deposit Token Address mismatch'
           );
@@ -754,7 +770,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
               ''
             );
 
-          const correlationId = await contractBosonRouter.correlationIds(
+          const correlationId = await contractBosonRouter.getCorrelationId(
             users.seller.address
           );
           assert.equal(
@@ -797,7 +813,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
         });
 
         it('Seller correlationId should be incremented after order is created', async () => {
-          const correlationId = await contractBosonRouter.correlationIds(
+          const correlationId = await contractBosonRouter.getCorrelationId(
             users.seller.address
           );
 
@@ -872,22 +888,30 @@ contract('Cashier and VoucherKernel', async (addresses) => {
             constants.QTY_1
           );
 
-          const paymentDetails = await contractVoucherKernel.paymentDetails(
+          const paymentMethod = await contractVoucherKernel.getVoucherPaymentMethod(
+            tokenSupplyKey
+          );
+
+          const addressTokenPrice = await contractVoucherKernel.getVoucherPriceToken(
+            tokenSupplyKey
+          );
+
+          const addressTokenDeposits = await contractVoucherKernel.getVoucherDepositToken(
             tokenSupplyKey
           );
 
           assert.equal(
-            paymentDetails.paymentMethod.toString(),
+            paymentMethod.toString(),
             paymentMethods.TKNETH,
             'Payment Method TKNETH not set correctly'
           );
           assert.equal(
-            paymentDetails.addressTokenPrice.toString(),
+            addressTokenPrice.toString(),
             contractBSNTokenPrice.address,
             'TKNETH Method Price Token Address mismatch'
           );
           assert.equal(
-            paymentDetails.addressTokenDeposits.toString(),
+            addressTokenDeposits.toString(),
             constants.ZERO_ADDRESS,
             'TKNETH Method Deposit Token Address mismatch'
           );
@@ -1015,7 +1039,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
               contractBSNTokenDeposit
             );
 
-          const correlationId = await contractBosonRouter.correlationIds(
+          const correlationId = await contractBosonRouter.getCorrelationId(
             users.seller.address
           );
           assert.equal(
@@ -1069,7 +1093,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
         });
 
         it('Seller correlationId should be incremented after order is created', async () => {
-          const correlationId = await contractBosonRouter.correlationIds(
+          const correlationId = await contractBosonRouter.getCorrelationId(
             users.seller.address
           );
 
@@ -1145,22 +1169,30 @@ contract('Cashier and VoucherKernel', async (addresses) => {
             constants.QTY_1
           );
 
-          const paymentDetails = await contractVoucherKernel.paymentDetails(
+          const paymentMethod = await contractVoucherKernel.getVoucherPaymentMethod(
+            tokenSupplyKey
+          );
+
+          const addressTokenPrice = await contractVoucherKernel.getVoucherPriceToken(
+            tokenSupplyKey
+          );
+
+          const addressTokenDeposits = await contractVoucherKernel.getVoucherDepositToken(
             tokenSupplyKey
           );
 
           assert.equal(
-            paymentDetails.paymentMethod.toString(),
+            paymentMethod.toString(),
             paymentMethods.TKNTKN,
             'Payment Method TKNTKN not set correctly'
           );
           assert.equal(
-            paymentDetails.addressTokenPrice.toString(),
+            addressTokenPrice.toString(),
             contractBSNTokenPrice.address,
             'TKNTKN Method Price Token Address mismatch'
           );
           assert.equal(
-            paymentDetails.addressTokenDeposits.toString(),
+            addressTokenDeposits.toString(),
             contractBSNTokenDeposit.address,
             'TKNTKN Method Deposit Token Address mismatch'
           );
@@ -1498,7 +1530,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
 
       timestamp = await Utils.getCurrTimestamp();
 
-      const correlationId = await contractBosonRouter.correlationIds(
+      const correlationId = await contractBosonRouter.getCorrelationId(
         users.seller.address
       );
       assert.equal(
@@ -1517,14 +1549,14 @@ contract('Cashier and VoucherKernel', async (addresses) => {
     });
 
     it('Seller correlationId should be incremented after supply is cancelled', async () => {
-      let prevCorrId = await contractBosonRouter.correlationIds(
+      let prevCorrId = await contractBosonRouter.getCorrelationId(
         users.seller.address
       );
 
       await contractBosonRouter.requestCancelOrFaultVoucherSet(tokenSupplyKey, {
         from: users.seller.address,
       });
-      let nextCorrId = await contractBosonRouter.correlationIds(
+      let nextCorrId = await contractBosonRouter.getCorrelationId(
         users.seller.address
       );
 
@@ -1562,7 +1594,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
       });
 
       it('Buyer correlationId should be zero initially', async () => {
-        const correlationId = await contractBosonRouter.correlationIds(
+        const correlationId = await contractBosonRouter.getCorrelationId(
           users.buyer.address
         );
 
@@ -1622,7 +1654,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
       });
 
       it('Buyer correlationId should be incremented after requesting a voucher', async () => {
-        const correlationId = await contractBosonRouter.correlationIds(
+        const correlationId = await contractBosonRouter.getCorrelationId(
           users.buyer.address
         );
 
@@ -1758,7 +1790,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
         });
 
         it('Buyer correlationId should be zero initially', async () => {
-          const correlationId = await contractBosonRouter.correlationIds(
+          const correlationId = await contractBosonRouter.getCorrelationId(
             users.buyer.address
           );
 
@@ -1834,7 +1866,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
         });
 
         it('Buyer correlationId should be incremented after requesting a voucher', async () => {
-          const correlationId = await contractBosonRouter.correlationIds(
+          const correlationId = await contractBosonRouter.getCorrelationId(
             users.buyer.address
           );
 
@@ -2022,7 +2054,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
         });
 
         it('Buyer correlationId should be zero initially', async () => {
-          const correlationId = await contractBosonRouter.correlationIds(
+          const correlationId = await contractBosonRouter.getCorrelationId(
             users.buyer.address
           );
 
@@ -2131,7 +2163,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
         });
 
         it('Buyer correlationId should be incremented after requesting a voucher', async () => {
-          const correlationId = await contractBosonRouter.correlationIds(
+          const correlationId = await contractBosonRouter.getCorrelationId(
             users.buyer.address
           );
 
@@ -2379,7 +2411,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
         });
 
         it('Buyer correlationId should be zero initially', async () => {
-          const correlationId = await contractBosonRouter.correlationIds(
+          const correlationId = await contractBosonRouter.getCorrelationId(
             users.buyer.address
           );
 
@@ -2465,7 +2497,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
         });
 
         it('Buyer correlationId should be incremented after requesting a voucher', async () => {
-          const correlationId = await contractBosonRouter.correlationIds(
+          const correlationId = await contractBosonRouter.getCorrelationId(
             users.buyer.address
           );
 
@@ -2713,7 +2745,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
         });
 
         it('Buyer correlationId should be zero initially', async () => {
-          const correlationId = await contractBosonRouter.correlationIds(
+          const correlationId = await contractBosonRouter.getCorrelationId(
             users.buyer.address
           );
 
@@ -2790,7 +2822,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
         });
 
         it('Buyer correlationId should be incremented after requesting a voucher', async () => {
-          const correlationId = await contractBosonRouter.correlationIds(
+          const correlationId = await contractBosonRouter.getCorrelationId(
             users.buyer.address
           );
 
@@ -3452,7 +3484,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
       });
 
       it('New Supply Owner correlationId should be incremented properly', async () => {
-        let correlationId = await contractBosonRouter.correlationIds(
+        let correlationId = await contractBosonRouter.getCorrelationId(
           users.other2.address
         );
         assert.equal(
@@ -3469,7 +3501,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
           {from: users.other1.address}
         );
 
-        correlationId = await contractBosonRouter.correlationIds(
+        correlationId = await contractBosonRouter.getCorrelationId(
           users.other2.address
         );
 
@@ -3485,10 +3517,10 @@ contract('Cashier and VoucherKernel', async (addresses) => {
           new BN(constants.QTY_1)
         );
 
-        actualOldOwnerBalanceFromEscrow = await contractCashier.escrow(
+        actualOldOwnerBalanceFromEscrow = await contractCashier.getEscrowAmount(
           users.other1.address
         );
-        actualNewOwnerBalanceFromEscrow = await contractCashier.escrow(
+        actualNewOwnerBalanceFromEscrow = await contractCashier.getEscrowAmount(
           users.other2.address
         );
 
@@ -3510,10 +3542,10 @@ contract('Cashier and VoucherKernel', async (addresses) => {
             from: users.other1.address,
           }
         ),
-          (actualOldOwnerBalanceFromEscrow = await contractCashier.escrow(
+          (actualOldOwnerBalanceFromEscrow = await contractCashier.getEscrowAmount(
             users.other1.address
           ));
-        actualNewOwnerBalanceFromEscrow = await contractCashier.escrow(
+        actualNewOwnerBalanceFromEscrow = await contractCashier.getEscrowAmount(
           users.other2.address
         );
 
@@ -3706,7 +3738,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
         }
 
         it('New Supply Owner correlationId should be incremented properly', async () => {
-          let correlationId = await contractBosonRouter.correlationIds(
+          let correlationId = await contractBosonRouter.getCorrelationId(
             users.other2.address
           );
           assert.equal(
@@ -3723,7 +3755,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
             {from: users.other1.address}
           );
 
-          correlationId = await contractBosonRouter.correlationIds(
+          correlationId = await contractBosonRouter.getCorrelationId(
             users.other2.address
           );
 
@@ -3999,7 +4031,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
         }
 
         it('New Supply Owner correlationId should be incremented properly', async () => {
-          let correlationId = await contractBosonRouter.correlationIds(
+          let correlationId = await contractBosonRouter.getCorrelationId(
             users.other2.address
           );
           assert.equal(
@@ -4016,7 +4048,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
             {from: users.other1.address}
           );
 
-          correlationId = await contractBosonRouter.correlationIds(
+          correlationId = await contractBosonRouter.getCorrelationId(
             users.other2.address
           );
 
@@ -4260,7 +4292,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
         }
 
         it('New Supply Owner correlationId should be incremented properly', async () => {
-          let correlationId = await contractBosonRouter.correlationIds(
+          let correlationId = await contractBosonRouter.getCorrelationId(
             users.other2.address
           );
           assert.equal(
@@ -4277,7 +4309,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
             {from: users.other1.address}
           );
 
-          correlationId = await contractBosonRouter.correlationIds(
+          correlationId = await contractBosonRouter.getCorrelationId(
             users.other2.address
           );
 
@@ -4293,10 +4325,10 @@ contract('Cashier and VoucherKernel', async (addresses) => {
             new BN(constants.QTY_1)
           );
 
-          actualOldOwnerBalanceFromEscrow = await contractCashier.escrow(
+          actualOldOwnerBalanceFromEscrow = await contractCashier.getEscrowAmount(
             users.other1.address
           );
-          actualNewOwnerBalanceFromEscrow = await contractCashier.escrow(
+          actualNewOwnerBalanceFromEscrow = await contractCashier.getEscrowAmount(
             users.other2.address
           );
 
@@ -4317,10 +4349,10 @@ contract('Cashier and VoucherKernel', async (addresses) => {
             {from: users.other1.address}
           );
 
-          actualOldOwnerBalanceFromEscrow = await contractCashier.escrow(
+          actualOldOwnerBalanceFromEscrow = await contractCashier.getEscrowAmount(
             users.other1.address
           );
-          actualNewOwnerBalanceFromEscrow = await contractCashier.escrow(
+          actualNewOwnerBalanceFromEscrow = await contractCashier.getEscrowAmount(
             users.other2.address
           );
 
@@ -4621,7 +4653,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
           tokenSupplyKey
         );
 
-        let correlationId = await contractBosonRouter.correlationIds(
+        let correlationId = await contractBosonRouter.getCorrelationId(
           users.other2.address
         );
         assert.equal(
@@ -4637,7 +4669,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
           {from: users.other1.address}
         );
 
-        correlationId = await contractBosonRouter.correlationIds(
+        correlationId = await contractBosonRouter.getCorrelationId(
           users.other2.address
         );
         assert.equal(
@@ -4657,10 +4689,10 @@ contract('Cashier and VoucherKernel', async (addresses) => {
           tokenSupplyKey
         );
 
-        actualOldOwnerBalanceFromEscrowEth = await contractCashier.escrow(
+        actualOldOwnerBalanceFromEscrowEth = await contractCashier.getEscrowAmount(
           users.other1.address
         );
-        actualNewOwnerBalanceFromEscrowEth = await contractCashier.escrow(
+        actualNewOwnerBalanceFromEscrowEth = await contractCashier.getEscrowAmount(
           users.other2.address
         );
 
@@ -4682,10 +4714,10 @@ contract('Cashier and VoucherKernel', async (addresses) => {
           }
         );
 
-        actualOldOwnerBalanceFromEscrowEth = await contractCashier.escrow(
+        actualOldOwnerBalanceFromEscrowEth = await contractCashier.getEscrowAmount(
           users.other1.address
         );
-        actualNewOwnerBalanceFromEscrowEth = await contractCashier.escrow(
+        actualNewOwnerBalanceFromEscrowEth = await contractCashier.getEscrowAmount(
           users.other2.address
         );
 
@@ -4933,7 +4965,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
             tokenSupplyKey
           );
 
-          let correlationId = await contractBosonRouter.correlationIds(
+          let correlationId = await contractBosonRouter.getCorrelationId(
             users.other2.address
           );
           assert.equal(
@@ -4949,7 +4981,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
             {from: users.other1.address}
           );
 
-          correlationId = await contractBosonRouter.correlationIds(
+          correlationId = await contractBosonRouter.getCorrelationId(
             users.other2.address
           );
           assert.equal(
@@ -4969,7 +5001,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
             tokenSupplyKey
           );
 
-          actualOldOwnerBalanceFromEscrowEth = await contractCashier.escrow(
+          actualOldOwnerBalanceFromEscrowEth = await contractCashier.getEscrowAmount(
             users.other1.address
           );
 
@@ -4978,7 +5010,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
             users.other1.address
           );
 
-          actualNewOwnerBalanceFromEscrowEth = await contractCashier.escrow(
+          actualNewOwnerBalanceFromEscrowEth = await contractCashier.getEscrowAmount(
             users.other2.address
           );
 
@@ -5016,7 +5048,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
             }
           );
 
-          actualOldOwnerBalanceFromEscrowEth = await contractCashier.escrow(
+          actualOldOwnerBalanceFromEscrowEth = await contractCashier.getEscrowAmount(
             users.other1.address
           );
 
@@ -5025,7 +5057,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
             users.other1.address
           );
 
-          actualNewOwnerBalanceFromEscrowEth = await contractCashier.escrow(
+          actualNewOwnerBalanceFromEscrowEth = await contractCashier.getEscrowAmount(
             users.other2.address
           );
 
@@ -5320,7 +5352,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
             tokenSupplyKey
           );
 
-          let correlationId = await contractBosonRouter.correlationIds(
+          let correlationId = await contractBosonRouter.getCorrelationId(
             users.other2.address
           );
           assert.equal(
@@ -5336,7 +5368,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
             {from: users.other1.address}
           );
 
-          correlationId = await contractBosonRouter.correlationIds(
+          correlationId = await contractBosonRouter.getCorrelationId(
             users.other2.address
           );
           assert.equal(
@@ -5678,7 +5710,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
             tokenSupplyKey
           );
 
-          let correlationId = await contractBosonRouter.correlationIds(
+          let correlationId = await contractBosonRouter.getCorrelationId(
             users.other2.address
           );
           assert.equal(
@@ -5694,7 +5726,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
             {from: users.other1.address}
           );
 
-          correlationId = await contractBosonRouter.correlationIds(
+          correlationId = await contractBosonRouter.getCorrelationId(
             users.other2.address
           );
           assert.equal(
@@ -5713,7 +5745,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
             tokenSupplyKey
           );
 
-          actualOldOwnerBalanceFromEscrowEth = await contractCashier.escrow(
+          actualOldOwnerBalanceFromEscrowEth = await contractCashier.getEscrowAmount(
             users.other1.address
           );
 
@@ -5722,7 +5754,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
             users.other1.address
           );
 
-          actualNewOwnerBalanceFromEscrowEth = await contractCashier.escrow(
+          actualNewOwnerBalanceFromEscrowEth = await contractCashier.getEscrowAmount(
             users.other2.address
           );
 
@@ -5759,7 +5791,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
               from: users.other1.address,
             }
           ),
-            (actualOldOwnerBalanceFromEscrowEth = await contractCashier.escrow(
+            (actualOldOwnerBalanceFromEscrowEth = await contractCashier.getEscrowAmount(
               users.other1.address
             ));
 
@@ -5768,7 +5800,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
             users.other1.address
           );
 
-          actualNewOwnerBalanceFromEscrowEth = await contractCashier.escrow(
+          actualNewOwnerBalanceFromEscrowEth = await contractCashier.getEscrowAmount(
             users.other2.address
           );
 

--- a/test/7_ admin_functionality.js
+++ b/test/7_ admin_functionality.js
@@ -133,7 +133,7 @@ contract('Admin functionality', async (addresses) => {
 
     it('Owner should be the deployer', async () => {
       let expectedOwner = users.deployer.address;
-      let owner = await contractERC1155ERC721.owner();
+      let owner = await contractERC1155ERC721.getOwner();
 
       assert.equal(owner, expectedOwner, 'Owner is not as expected');
     });

--- a/testHelpers/constants.js
+++ b/testHelpers/constants.js
@@ -81,11 +81,7 @@ let VOUCHER_STATUS_FIELDS = {};
 let PROMISE_ORDER_FIELDS = {};
 {
   let index = 0;
-  let keys = [
-    'price',
-    'depositSe',
-    'depositBu'
-  ];
+  let keys = ['price', 'depositSe', 'depositBu'];
   for (let key of keys) {
     PROMISE_ORDER_FIELDS[key] = index++;
   }
@@ -136,5 +132,5 @@ module.exports = {
   TWO,
   PROMISE_DATA_FIELDS,
   VOUCHER_STATUS_FIELDS,
-  PROMISE_ORDER_FIELDS
+  PROMISE_ORDER_FIELDS,
 };

--- a/testHelpers/constants.js
+++ b/testHelpers/constants.js
@@ -78,6 +78,19 @@ let VOUCHER_STATUS_FIELDS = {};
   }
 }
 
+let PROMISE_ORDER_FIELDS = {};
+{
+  let index = 0;
+  let keys = [
+    'price',
+    'depositSe',
+    'depositBu'
+  ];
+  for (let key of keys) {
+    PROMISE_ORDER_FIELDS[key] = index++;
+  }
+}
+
 module.exports = {
   ASSET_VERSION,
   ASSET_TITLE,
@@ -123,4 +136,5 @@ module.exports = {
   TWO,
   PROMISE_DATA_FIELDS,
   VOUCHER_STATUS_FIELDS,
+  PROMISE_ORDER_FIELDS
 };

--- a/testHelpers/constants.js
+++ b/testHelpers/constants.js
@@ -6,6 +6,7 @@ const SECONDS_IN_DAY = 86400;
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 const ZERO = new BN(0);
 const ONE = new BN(1);
+const TWO = new BN(2);
 
 // asset
 const ASSET_VERSION = '0x3132';
@@ -53,6 +54,30 @@ const ABOVE_ETH_LIMIT = (10 * 10 ** 18).toString();
 const TOKEN_LIMIT = (5 * 10 ** 18).toString();
 const ABOVE_TOKEN_LIMIT = (10 * 10 ** 18).toString();
 
+let PROMISE_DATA_FIELDS = {};
+{
+  let index = 0;
+  let keys = ['promiseId', 'nonce', 'validFrom', 'validTo', 'idx'];
+  for (let key of keys) {
+    PROMISE_DATA_FIELDS[key] = index++;
+  }
+}
+
+let VOUCHER_STATUS_FIELDS = {};
+{
+  let index = 0;
+  let keys = [
+    'status',
+    'isPaymentReleased',
+    'isDepositsReleased',
+    'complainPeriodStart',
+    'cancelFaultPeriodStart',
+  ];
+  for (let key of keys) {
+    VOUCHER_STATUS_FIELDS[key] = index++;
+  }
+}
+
 module.exports = {
   ASSET_VERSION,
   ASSET_TITLE,
@@ -95,4 +120,7 @@ module.exports = {
   ABOVE_TOKEN_LIMIT,
   ZERO,
   ONE,
+  TWO,
+  PROMISE_DATA_FIELDS,
+  VOUCHER_STATUS_FIELDS,
 };


### PR DESCRIPTION
This is the PR for the "Make state variables private so that default getters functions are not generated" card.
Make state variables private. Needed to add a few functions to facilitate testing. Modified unit tests where they were using the generated getters. Some changes to reference app code will be required, so merging must be coordinated