### PR TITLE
Add getters for private variables

### DIFF
--- a/contracts/BosonRouter.sol
+++ b/contracts/BosonRouter.sol
@@ -30,9 +30,9 @@ contract BosonRouter is
 
     using SafeMath for uint256;
 
-    address public cashierAddress;
-    address public voucherKernel;
-    address public fundLimitsOracle;
+    address private cashierAddress;
+    address private voucherKernel;
+    address private fundLimitsOracle;
 
     event LogOrderCreated(
         uint256 indexed _tokenIdSupply,
@@ -715,5 +715,44 @@ contract BosonRouter is
         returns (uint256)
     {
         return correlationIds[_party];
+    }
+
+    /**
+     * @notice Get the address of Cashier contract
+     * @return Address of Cashier address
+     */
+    function getCashierAddress() 
+        external 
+        view 
+        override
+        returns (address)
+    {
+        return cashierAddress;
+    }
+
+     /**
+     * @notice Get the address of Voucher Kernel contract
+     * @return Address of Voucher Kernel contract
+     */
+    function getVoucherKernelAddress() 
+        external 
+        view 
+        override
+        returns (address)
+    {
+        return voucherKernel;
+    }
+
+    /**
+     * @notice Get the address of Fund Limits Oracle contract
+     * @return Address of Fund Limits Oracle contract
+     */
+    function getFundLimitOracleAddress() 
+        external 
+        view 
+        override
+        returns (address)
+    {
+        return fundLimitsOracle;
     }
 }

--- a/contracts/Cashier.sol
+++ b/contracts/Cashier.sol
@@ -1051,6 +1051,53 @@ contract Cashier is ICashier, UsingHelpers, ReentrancyGuard, Ownable, Pausable {
     // // // // // // // //
 
     /**
+     * @notice Get the address of Voucher Kernel contract
+     * @return Address of Voucher Kernel contract
+     */
+    function getVoucherKernelAddress() 
+        external 
+        view 
+        override
+        returns (address)
+    {
+        return voucherKernel;
+    }
+
+    /**
+     * @notice Get the address of Boson Router contract
+     * @return Address of Boson Router contract
+     */
+    function getBosonRouterAddress() 
+        external 
+        view 
+        override
+        returns (address)
+    {
+        return bosonRouterAddress;
+    }
+
+    /**
+     * @notice Get the address of ERC1155ERC721 contract
+     * @return Address of ERC1155ERC721 contract
+     */
+    function getTokensContractAddress() 
+        external 
+        view 
+        override
+        returns (address)
+    {
+        return tokensContractAddress;
+    }
+
+    /**
+     * @notice Ensure whether or not contract has been set to disaster state 
+     * @return disasterState
+     */
+    function isDisasterStateSet() external view override returns(bool) {
+        return disasterState;
+    }
+
+    /**
      * @notice Get the amount in escrow of an address
      * @param _account  The address of an account to query
      * @return          The balance in escrow

--- a/contracts/ERC1155ERC721.sol
+++ b/contracts/ERC1155ERC721.sol
@@ -874,5 +874,31 @@ contract ERC1155ERC721 is IERC1155, IERC721, IERC1155ERC721 {
     {
         return owner;
     }
+
+    /**
+     * @notice Get the address of Voucher Kernel contract
+     * @return Address of Voucher Kernel contract
+     */
+    function getVoucherKernelAddress() 
+        external 
+        view 
+        override
+        returns (address)
+    {
+        return voucherKernelAddress;
+    }
+
+    /**
+     * @notice Get the address of Cashier contract
+     * @return Address of Cashier address
+     */
+    function getCashierAddress() 
+        external 
+        view 
+        override
+        returns (address)
+    {
+        return cashierAddress;
+    }
     
 }

--- a/contracts/VoucherKernel.sol
+++ b/contracts/VoucherKernel.sol
@@ -67,7 +67,7 @@ contract VoucherKernel is IVoucherKernel, Ownable, Pausable, UsingHelpers {
 
     //ID reqs
     mapping(uint256 => uint256) private typeCounters; //counter for ID of a particular type of NFT
-    uint256 public constant MASK_TYPE = uint256(uint128(~0)) << 128; //the type mask in the upper 128 bits
+    uint256 private constant MASK_TYPE = uint256(uint128(~0)) << 128; //the type mask in the upper 128 bits
     //1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
 
     uint256 private constant MASK_NF_INDEX = uint128(~0); //the non-fungible index mask in the lower 128

--- a/contracts/VoucherKernel.sol
+++ b/contracts/VoucherKernel.sol
@@ -30,7 +30,7 @@ contract VoucherKernel is IVoucherKernel, Ownable, Pausable, UsingHelpers {
     using SafeMath for uint256;
 
     //AssetRegistry assetRegistry;
-    address public tokensContract;
+    address private tokensContract;
 
     //promise for an asset could be reusable, but simplified here for brevity
     struct Promise {
@@ -1296,5 +1296,18 @@ contract VoucherKernel is IVoucherKernel, Ownable, Pausable, UsingHelpers {
         returns (bytes32) 
     {
         return ordersPromise[_tokenIdSupply];
+    }
+
+    /**
+     * @notice Get the address of ERC1155ERC721 contract
+     * @return Address of ERC1155ERC721 contract
+     */
+    function getTokensContractAddress() 
+        external 
+        view 
+        override
+        returns (address)
+    {
+        return tokensContract;
     }
 }

--- a/contracts/interfaces/IBosonRouter.sol
+++ b/contracts/interfaces/IBosonRouter.sol
@@ -145,4 +145,22 @@ interface IBosonRouter {
      * @return the specified party's correlation Id
      */
     function getCorrelationId(address _party) external view returns (uint256);
+
+    /**
+     * @notice Get the address of Cashier contract
+     * @return Address of Cashier address
+     */
+    function getCashierAddress() external view returns (address);
+
+    /**
+     * @notice Get the address of Voucher Kernel contract
+     * @return Address of Voucher Kernel contract
+     */
+    function getVoucherKernelAddress() external view returns (address);
+
+    /**
+     * @notice Get the address of Fund Limits Oracle contract
+     * @return Address of Fund Limits Oracle contract
+     */
+    function getFundLimitOracleAddress() external view returns (address);
 }

--- a/contracts/interfaces/ICashier.sol
+++ b/contracts/interfaces/ICashier.sol
@@ -91,6 +91,30 @@ interface ICashier {
     ) external;
 
     /**
+     * @notice Get the address of Voucher Kernel contract
+     * @return Address of Voucher Kernel contract
+     */
+    function getVoucherKernelAddress() external view returns (address);
+
+    /**
+     * @notice Get the address of Boson Router contract
+     * @return Address of Boson Router contract
+     */
+    function getBosonRouterAddress() external view returns (address);
+
+    /**
+     * @notice Get the address of ERC1155ERC721 contract
+     * @return Address of ERC1155ERC721 contract
+     */
+    function getTokensContractAddress() external view returns (address);
+
+    /**
+     * @notice Ensure whether or not contract has been set to disaster state
+     * @return disasterState
+     */
+    function isDisasterStateSet() external view returns (bool);
+
+    /**
      * @notice Get the amount in escrow of an address
      * @param _token  The address of a token to query
      * @param _account  The address of an account to query

--- a/contracts/interfaces/IERC1155ERC721.sol
+++ b/contracts/interfaces/IERC1155ERC721.sol
@@ -55,4 +55,16 @@ interface IERC1155ERC721 {
      * @return Address of the owner
      */
     function getOwner() external view returns (address);
+
+    /**
+     * @notice Get the address of Voucher Kernel contract
+     * @return Address of Voucher Kernel contract
+     */
+    function getVoucherKernelAddress() external view returns (address);
+
+    /**
+     * @notice Get the address of Cashier contract
+     * @return Address of Cashier address
+     */
+    function getCashierAddress() external view returns (address);
 }

--- a/contracts/interfaces/IVoucherKernel.sol
+++ b/contracts/interfaces/IVoucherKernel.sol
@@ -386,4 +386,10 @@ interface IVoucherKernel {
         external
         view
         returns (bytes32);
+
+    /**
+     * @notice Get the address of ERC1155ERC721 contract
+     * @return Address of ERC1155ERC721 contract
+     */
+    function getTokensContractAddress() external view returns (address);
 }

--- a/contracts/mocks/MockBosonRouter.sol
+++ b/contracts/mocks/MockBosonRouter.sol
@@ -711,4 +711,38 @@ contract MockBosonRouter is
     {
         return correlationIds[_party];
     }
+
+    /**
+     * @notice Get the address of Cashier contract
+     * @return Address of Cashier address
+     */
+    function getCashierAddress() external view override returns (address) {
+        return cashierAddress;
+    }
+
+    /**
+     * @notice Get the address of Voucher Kernel contract
+     * @return Address of Voucher Kernel contract
+     */
+    function getVoucherKernelAddress()
+        external
+        view
+        override
+        returns (address)
+    {
+        return voucherKernel;
+    }
+
+    /**
+     * @notice Get the address of Fund Limits Oracle contract
+     * @return Address of Fund Limits Oracle contract
+     */
+    function getFundLimitOracleAddress()
+        external
+        view
+        override
+        returns (address)
+    {
+        return fundLimitsOracle;
+    }
 }

--- a/test/1_test_fullpath.js
+++ b/test/1_test_fullpath.js
@@ -86,6 +86,42 @@ contract('Voucher tests', async (addresses) => {
     await deployContracts();
   });
 
+  describe("Contract Addresses Getters", function () {
+    it("Should have set contract addresses properly for Boson Router", async () => {
+      const flo = await contractBosonRouter.getFundLimitOracleAddress()
+      const cashier = await contractBosonRouter.getCashierAddress()
+      const voucherKernel = await contractBosonRouter.getVoucherKernelAddress()
+
+      assert.equal(flo, contractFundLimitsOracle.address);
+      assert.equal(cashier, contractCashier.address);
+      assert.equal(voucherKernel, contractVoucherKernel.address);
+    })
+
+    it("Should have set contract addresses properly for ERC1155ERC721", async () => {
+      const voucherKernel = await contractERC1155ERC721.getVoucherKernelAddress()
+      const cashier = await contractERC1155ERC721.getCashierAddress()
+
+      assert.equal(voucherKernel, contractVoucherKernel.address);
+      assert.equal(cashier, contractCashier.address);
+    })
+
+    it("Should have set contract addresses properly for VoucherKernel", async () => {
+      const tokensContract = await contractVoucherKernel.getTokensContractAddress()
+
+      assert.equal(tokensContract, contractERC1155ERC721.address);
+    })
+
+    it("Should have set contract addresses properly for Cashier", async () => {
+      const voucherKernel = await contractCashier.getVoucherKernelAddress()
+      const bosonRouter = await contractCashier.getBosonRouterAddress()
+      const tokensContract = await contractCashier.getTokensContractAddress()
+
+      assert.equal(voucherKernel, contractVoucherKernel.address);
+      assert.equal(bosonRouter, contractBosonRouter.address);
+      assert.equal(tokensContract, contractERC1155ERC721.address);
+    })
+  })
+
   describe('Direct minting', function () {
     it('must fail: unauthorized minting ERC-1155', async () => {
       await truffleAssert.reverts(

--- a/test/1_test_fullpath.js
+++ b/test/1_test_fullpath.js
@@ -86,41 +86,41 @@ contract('Voucher tests', async (addresses) => {
     await deployContracts();
   });
 
-  describe("Contract Addresses Getters", function () {
-    it("Should have set contract addresses properly for Boson Router", async () => {
-      const flo = await contractBosonRouter.getFundLimitOracleAddress()
-      const cashier = await contractBosonRouter.getCashierAddress()
-      const voucherKernel = await contractBosonRouter.getVoucherKernelAddress()
+  describe('Contract Addresses Getters', function () {
+    it('Should have set contract addresses properly for Boson Router', async () => {
+      const flo = await contractBosonRouter.getFundLimitOracleAddress();
+      const cashier = await contractBosonRouter.getCashierAddress();
+      const voucherKernel = await contractBosonRouter.getVoucherKernelAddress();
 
       assert.equal(flo, contractFundLimitsOracle.address);
       assert.equal(cashier, contractCashier.address);
       assert.equal(voucherKernel, contractVoucherKernel.address);
-    })
+    });
 
-    it("Should have set contract addresses properly for ERC1155ERC721", async () => {
-      const voucherKernel = await contractERC1155ERC721.getVoucherKernelAddress()
-      const cashier = await contractERC1155ERC721.getCashierAddress()
+    it('Should have set contract addresses properly for ERC1155ERC721', async () => {
+      const voucherKernel = await contractERC1155ERC721.getVoucherKernelAddress();
+      const cashier = await contractERC1155ERC721.getCashierAddress();
 
       assert.equal(voucherKernel, contractVoucherKernel.address);
       assert.equal(cashier, contractCashier.address);
-    })
+    });
 
-    it("Should have set contract addresses properly for VoucherKernel", async () => {
-      const tokensContract = await contractVoucherKernel.getTokensContractAddress()
+    it('Should have set contract addresses properly for VoucherKernel', async () => {
+      const tokensContract = await contractVoucherKernel.getTokensContractAddress();
 
       assert.equal(tokensContract, contractERC1155ERC721.address);
-    })
+    });
 
-    it("Should have set contract addresses properly for Cashier", async () => {
-      const voucherKernel = await contractCashier.getVoucherKernelAddress()
-      const bosonRouter = await contractCashier.getBosonRouterAddress()
-      const tokensContract = await contractCashier.getTokensContractAddress()
+    it('Should have set contract addresses properly for Cashier', async () => {
+      const voucherKernel = await contractCashier.getVoucherKernelAddress();
+      const bosonRouter = await contractCashier.getBosonRouterAddress();
+      const tokensContract = await contractCashier.getTokensContractAddress();
 
       assert.equal(voucherKernel, contractVoucherKernel.address);
       assert.equal(bosonRouter, contractBosonRouter.address);
       assert.equal(tokensContract, contractERC1155ERC721.address);
-    })
-  })
+    });
+  });
 
   describe('Direct minting', function () {
     it('must fail: unauthorized minting ERC-1155', async () => {

--- a/test/3_withdrawals.js
+++ b/test/3_withdrawals.js
@@ -5253,11 +5253,8 @@ contract('Cashier withdrawals ', async (addresses) => {
         truffleAssert.eventEmitted(tx, 'LogDisasterStateSet', (ev) => {
           return ev._triggeredBy == users.deployer.address;
         });
-      });
 
-      it('Disaster State should be set successfully', async () => {
         const disasterState = await contractCashier.isDisasterStateSet();
-
         assert.isTrue(disasterState);
       });
 

--- a/test/3_withdrawals.js
+++ b/test/3_withdrawals.js
@@ -5238,12 +5238,25 @@ contract('Cashier withdrawals ', async (addresses) => {
         );
       });
 
+      it('Disaster State should be falsy value initially', async () => {
+        const disasterState = await contractCashier.isDisasterStateSet()
+
+        assert.isFalse(disasterState)
+      });
+
       it('Admin should be able to set the Cashier at disaster state', async () => {
-        const tx = await contractCashier.setDisasterState();
+        const cashier = await Cashier.at(await contractBosonRouter.getCashierAddress())
+        const tx = await cashier.setDisasterState();
 
         truffleAssert.eventEmitted(tx, 'LogDisasterStateSet', (ev) => {
           return ev._triggeredBy == users.deployer.address;
         });
+      });
+
+      it('Disaster State should be set successfully', async () => {
+        const disasterState = await contractCashier.isDisasterStateSet()
+
+        assert.isTrue(disasterState)
       });
 
       it('Buyer should be able to withdraw all the funds locked in escrow', async () => {

--- a/test/3_withdrawals.js
+++ b/test/3_withdrawals.js
@@ -5239,13 +5239,15 @@ contract('Cashier withdrawals ', async (addresses) => {
       });
 
       it('Disaster State should be falsy value initially', async () => {
-        const disasterState = await contractCashier.isDisasterStateSet()
+        const disasterState = await contractCashier.isDisasterStateSet();
 
-        assert.isFalse(disasterState)
+        assert.isFalse(disasterState);
       });
 
       it('Admin should be able to set the Cashier at disaster state', async () => {
-        const cashier = await Cashier.at(await contractBosonRouter.getCashierAddress())
+        const cashier = await Cashier.at(
+          await contractBosonRouter.getCashierAddress()
+        );
         const tx = await cashier.setDisasterState();
 
         truffleAssert.eventEmitted(tx, 'LogDisasterStateSet', (ev) => {
@@ -5254,9 +5256,9 @@ contract('Cashier withdrawals ', async (addresses) => {
       });
 
       it('Disaster State should be set successfully', async () => {
-        const disasterState = await contractCashier.isDisasterStateSet()
+        const disasterState = await contractCashier.isDisasterStateSet();
 
-        assert.isTrue(disasterState)
+        assert.isTrue(disasterState);
       });
 
       it('Buyer should be able to withdraw all the funds locked in escrow', async () => {


### PR DESCRIPTION
Further to #106 this PR makes state variables private throughout the entire codebase, and expose explicit getters for the one needed in some specific cases as "disaster state", as long as the contract addresses for transparency. @hswopeams, if the document you wrote about that could be applied here, I am happy to include it as additional ref. 