### PR TITLE
Added run task for contracts & updated README & added mock token deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,20 @@ the latest deployment details here, as well.
 For more details about how Boson Protocol works and how you might make use of
 it, please see the [documentation site](https://docs.bosonprotocol.io/).  
 
+---
 **Table of Contents**
 
 - [Local Development](#local-development)
-- [Testing](#testing)
-- [Code Linting](#code-linting)
-- [Documentation](#documentation)
+  - [Prerequisites](#prerequisites)
+  - [Build](#build)
+  - [Run](#run)
+  - [Test](#test)
+  - [Code Linting & Formatting](#code-linting--formatting)
+- [Documentation](#documentation)  
 - [Contributing](#contributing)
 - [License](#license)
 
+---
 ## Local Development
 
 ### Prerequisites
@@ -43,7 +48,8 @@ For instructions on how to get set up with these specific versions:
 * See the [OS X guide](docs/setup/osx.md) if you are on a Mac.
 * See the [Linux guide](docs/setup/linux.md) if you use a Linux distribution.
 
-### Running the build
+---
+### Build
 
 We have a fully automated local build process to check that your changes are
 good to be merged. To run the build:
@@ -68,9 +74,17 @@ To compile the contracts:
 ./go contracts:compile
 ```
 
-## Testing
+---
+### Run
+To deploy a local instance of the contracts run the following command:
+```shell
+./go contracts:run
+```
 
-### Unit Tests
+---
+### Test
+
+#### Unit Tests
 
 All contracts are thoroughly unit tested using 
 [Truffle's JavaScript testing](https://www.trufflesuite.com/docs/truffle/testing/writing-tests-in-javascript) 
@@ -94,7 +108,7 @@ otherwise, create a JSON file creating accounts in the same format as
 ./go "tests:unit[<port>,<path-to-accounts-json>]"
 ```
 
-### Coverage
+#### Coverage
 
 We use [solidity-coverage](https://github.com/sc-forks/solidity-coverage) to 
 provide test coverage reports. 
@@ -108,12 +122,13 @@ To check the test coverage:
 `solidity-coverage` runs its own instance of Ganache internally, as well as
 instrumenting contracts before running.
 
-### Interaction Tests
+#### Interaction Tests
 
 To run the interaction tests, follow the instructions in the
 [interaction tests README.md](testUserInteractions/README.md).
 
-## Code Linting
+---
+### Code Linting & Formatting
 
 Both the contracts themselves and the tests are linted and formatted as part of
 the build process.
@@ -161,12 +176,14 @@ Similarly, for the tests, to perform the same tasks:
 ./go tests:format_fix
 ```
 
+---
 ## Documentation
 
 For an overview of the contracts and their responsibilities, see 
 [Overview](docs/contracts/overview.md).  
 The whitepaper is available through the project's [website](https://www.bosonprotocol.io/).
 
+---
 ## Contributing
 
 We welcome contributions! Until now, Boson Protocol has been largely worked on by a small dedicated team. However, the ultimate goal is for all of the Boson Protocol repositories to be fully owned by the community and contributors. Issues, pull requests, suggestions, and any sort of involvement are more than welcome.
@@ -179,6 +196,7 @@ All PRs must pass all tests before being merged.
 
 By being in this community, you agree to the [Code of Conduct](CODE_OF_CONDUCT.md). Take a look at it, if you haven't already.
 
+---
 ## License
 
 Licensed under [LGPL v3](LICENSE).

--- a/README.md
+++ b/README.md
@@ -83,15 +83,15 @@ To deploy instances of the contracts for local development without prior knowled
 ./go contracts:run
 ```
 
-This command starts up Ganache on a random port and migrates all contracts to the Ganache instance. The Ganache instance will remain running the the background, even though the command prompt is available.
+This command starts up Ganache on a random port and migrates all contracts to the Ganache instance. The Ganache instance will remain running in the background, even though the command prompt returns.
 The pid of the Ganache instance is written to a file in the run/pid directory.
 
-To stop the Ganache instance, run the folloing command:
+To stop the Ganache instance, run the following command:
 ```shell
 ./go ganache:stop
 ```
 
-If preferred by those who are familiar with Truffle and Ganache, Ganache can be started up manually in a terminal using the command (or other desired port):
+If preferred by those who are familiar with Truffle and Ganache, the standard Truffle and Ganache commands can be used. Ganache can be started up manually in a terminal using the command:
 ```shell
   node ./node_modules/.bin/ganache-cli --port 8545 --allowUnlimitedContractSize --acctKeys build/ganache/accounts-8545.json
 ```

--- a/README.md
+++ b/README.md
@@ -52,14 +52,16 @@ For instructions on how to get set up with these specific versions:
 ### Build
 
 We have a fully automated local build process to check that your changes are
-good to be merged. To run the build:
+good to be merged. It is based on a script called `go`, which is implemented using Ruby and Rake. Always run the `go` script before committing or pushing to GitHub.
+To run the build:
 
 ```shell script
 ./go
 ````
 
 By default, the build process fetches all dependencies, compiles, lints, 
-formats and tests the codebase. There are also tasks for each step. This and
+formats and tests the codebase. If the linting or formatting tasks find problems, the script will attempt to fix them silently, so always check for changes in your files before committing or pushing to GitHub.
+There are also tasks for each step that can be run separately. This and
 subsequent sections provide more details of each of the tasks.
 
 To fetch dependencies:
@@ -76,10 +78,28 @@ To compile the contracts:
 
 ---
 ### Run
-To deploy a local instance of the contracts run the following command:
+To deploy instances of the contracts for local development without prior knowledge Ganache and Truffle, run the following command:
 ```shell
 ./go contracts:run
 ```
+
+This command starts up Ganache on a random port and migrates all contracts to the Ganache instance. The Ganache instance will remain running the the background, even though the command prompt is available.
+The pid of the Ganache instance is written to a file in the run/pid directory.
+
+To stop the Ganache instance, run the folloing command:
+```shell
+./go ganache:stop
+```
+
+If preferred by those who are familiar with Truffle and Ganache, Ganache can be started up manually in a terminal using the command (or other desired port):
+```shell
+  node ./node_modules/.bin/ganache-cli --port 8545 --allowUnlimitedContractSize --acctKeys build/ganache/accounts-8545.json
+```
+In a separate terminal, contracts can be deployed using
+```shell
+  ./node_modules/.bin/truffle migrate
+```
+One of the contracts that gets deployed locally is a mock contract that represents the $BOSON token. The mock exists for unit testing purposes and so that those who want to develop against the protocol locally don't have to point to a testnet deployment of the $BOSON token.
 
 ---
 ### Test

--- a/Rakefile
+++ b/Rakefile
@@ -69,6 +69,19 @@ namespace :dependencies do
 end
 
 namespace :contracts do
+  desc "Run all contracts (must be manually stopped)"
+  task :run, [:port, :account_keys_file] =>
+    [:'ganache:start'] do |_, args|
+    Ganache.on_available_port(
+      allow_unlimited_contract_size: true) do |ganache|
+      sh({
+           "HOST" => "127.0.0.1",
+           "PORT" => "#{ganache.port}",
+           "ACCOUNT_KEYS_FILE" => "#{ganache.account_keys_file}"
+         }, 'npm', 'run', 'contracts:run')
+    end
+  end
+
   desc "Compile all contracts"
   task :compile => [:'dependencies:install'] do
     sh('npm', 'run', 'contracts:compile')

--- a/migrations/2_deploy_mock_token_local_only.js
+++ b/migrations/2_deploy_mock_token_local_only.js
@@ -4,7 +4,6 @@ const FundLimitsOracle = artifacts.require('FundLimitsOracle');
 
 module.exports = async function(deployer, network, accounts) {
     console.log("network: ", network);
-    console.log("accounts: ", accounts);
 
     //Only deploy the mock token for running contracts locally
     if(network == 'development' || network == 'test'){
@@ -20,5 +19,7 @@ module.exports = async function(deployer, network, accounts) {
             mockBOSONToken.address,
             TOKEN_LIMIT
         );
+    } else {
+        console.log("NOT deploying mock token");
     }
 };

--- a/migrations/2_deploy_mock_token_local_only.js
+++ b/migrations/2_deploy_mock_token_local_only.js
@@ -1,0 +1,24 @@
+
+const MockERC20Permit = artifacts.require("MockERC20Permit")
+const FundLimitsOracle = artifacts.require('FundLimitsOracle');
+
+module.exports = async function(deployer, network, accounts) {
+    console.log("network: ", network);
+    console.log("accounts: ", accounts);
+
+    //Only deploy the mock token for running contracts locally
+    if(network == 'development' || network == 'test'){
+        const TOKEN_LIMIT = (5 * 10 ** 18).toString();
+        const fundsLimitOracle = await FundLimitsOracle.deployed();
+
+        //Deploy a mock BOSON token
+        const mockBOSONToken = await deployer.deploy(MockERC20Permit, "MockBOSONToken", "MBOSON");
+        console.log("Mock BOSON Token Address: ", mockBOSONToken.address);
+     
+        //Set token limit
+        await fundsLimitOracle.setTokenLimit(
+            mockBOSONToken.address,
+            TOKEN_LIMIT
+        );
+    }
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "contracts:run": "truffle migrate --network development",
+    "contracts:run": "truffle migrate --network test",
     "contracts:compile": "truffle compile --all",
     "contracts:lint": "solhint contracts/**/*.sol -w 0",
     "contracts:lint-fix": "solhint contracts/**/*.sol -w 0 --fix",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "test"
   },
   "scripts": {
+    "contracts:run": "truffle migrate --network development",
     "contracts:compile": "truffle compile --all",
     "contracts:lint": "solhint contracts/**/*.sol -w 0",
     "contracts:lint-fix": "solhint contracts/**/*.sol -w 0 --fix",


### PR DESCRIPTION
This is related to: https://app.asana.com/0/1199560399769920/1200478117062022
AND: https://app.asana.com/0/1199560399769920/1200484274111156

This adds:
 - a package.json script for running the contracts via truffle migrate (using the development network)
 - a rakefile/go task for running the contracts (executes the above package.json script)
 - updates to the README to reflect these changes