### PR TITLE
Remove extra using SafeMath line

### DIFF
--- a/contracts/BosonRouter.sol
+++ b/contracts/BosonRouter.sol
@@ -28,8 +28,6 @@ contract BosonRouter is
 
     mapping(address => uint256) private correlationIds; // whenever a seller or a buyer interacts with the smart contract, a personal txID is emitted from an event.
 
-    using SafeMath for uint256;
-
     address private cashierAddress;
     address private voucherKernel;
     address private fundLimitsOracle;

--- a/contracts/mocks/MockBosonRouter.sol
+++ b/contracts/mocks/MockBosonRouter.sol
@@ -29,8 +29,6 @@ contract MockBosonRouter is
 
     mapping(address => uint256) private correlationIds; // whenever a seller or a buyer interacts with the smart contract, a personal txID is emitted from an event.
 
-    using SafeMath for uint256;
-
     address public cashierAddress;
     address public voucherKernel;
     address public fundLimitsOracle;


### PR DESCRIPTION
The `using SafeMath for uint256;` was duplicated on line 31, probably due to a merge. This PR removes the duplicate line.