### PR TITLE
Set complain period on CoF

### DIFF
--- a/contracts/VoucherKernel.sol
+++ b/contracts/VoucherKernel.sol
@@ -692,6 +692,8 @@ contract VoucherKernel is IVoucherKernel, Ownable, Pausable, UsingHelpers {
                         tPromise.validTo + complainPeriod + cancelFaultPeriod,
                     "COFPERIOD_EXPIRED"
                 ); //hex"46" FISSION.code(FISSION.Category.Availability, FISSION.Status.Expired)
+                vouchersStatus[_tokenIdVoucher].complainPeriodStart = block
+                    .timestamp;
             } else {
                 require(
                     block.timestamp <=

--- a/test/2_test_fullpath_with_permit.js
+++ b/test/2_test_fullpath_with_permit.js
@@ -2964,7 +2964,7 @@ contract('Cashier and VoucherKernel', async (addresses) => {
       });
     });
 
-    describe('[NEGATIVE] Common voucher interactions after expiry', () => {
+    describe('Common voucher interactions after expiry', () => {
       const TEN_MINUTES = 10 * constants.ONE_MINUTE;
       const cancelPeriod = constants.ONE_MINUTE;
       const complainPeriod = constants.ONE_MINUTE;
@@ -3229,6 +3229,186 @@ contract('Cashier and VoucherKernel', async (addresses) => {
         await truffleAssert.reverts(
           utils.complain(voucherID, users.buyer.address),
           truffleAssert.ErrorType.reverts
+        );
+      });
+
+      it('[COMMIT->EXPIRY TRIGGERED->CANCEL] Seller should be able to cancel within the cancel period after expiry triggered', async () => {
+        const ONE_WEEK = 7 * constants.SECONDS_IN_DAY;
+        await contractVoucherKernel.setComplainPeriod(ONE_WEEK);
+        await contractVoucherKernel.setCancelFaultPeriod(ONE_WEEK);
+
+        const voucherID = await utils.commitToBuy(
+          users.buyer,
+          users.seller,
+          TOKEN_SUPPLY_ID
+        );
+
+        await timemachine.advanceTimeSeconds(ONE_WEEK);
+
+        let expiryTx = await contractVoucherKernel.triggerExpiration(voucherID);
+
+        await truffleAssert.eventEmitted(
+          expiryTx,
+          'LogExpirationTriggered',
+          (ev) => {
+            return ev._triggeredBy === users.deployer.address;
+          }
+        );
+
+        let cancelTx = await utils.cancel(voucherID, users.seller.address);
+
+        const internalCancel = await truffleAssert.createTransactionResult(
+          contractVoucherKernel,
+          cancelTx.tx
+        );
+        await truffleAssert.eventEmitted(
+          internalCancel,
+          'LogVoucherFaultCancel',
+          (ev) => {
+            return ev._tokenIdVoucher.toString() == voucherID;
+          }
+        );
+      });
+
+      it('[COMMIT->EXPIRY TRIGGERED->COMPLAIN] Buyer should be able to complain within the complain period after expiry triggered', async () => {
+        const ONE_WEEK = 7 * constants.SECONDS_IN_DAY;
+        await contractVoucherKernel.setComplainPeriod(ONE_WEEK);
+        await contractVoucherKernel.setCancelFaultPeriod(ONE_WEEK);
+
+        const voucherID = await utils.commitToBuy(
+          users.buyer,
+          users.seller,
+          TOKEN_SUPPLY_ID
+        );
+
+        await timemachine.advanceTimeSeconds(ONE_WEEK);
+
+        let expiryTx = await contractVoucherKernel.triggerExpiration(voucherID);
+
+        await truffleAssert.eventEmitted(
+          expiryTx,
+          'LogExpirationTriggered',
+          (ev) => {
+            return ev._triggeredBy === users.deployer.address;
+          }
+        );
+
+        let complainTx = await utils.complain(voucherID, users.buyer.address);
+
+        const internalComplain = await truffleAssert.createTransactionResult(
+          contractVoucherKernel,
+          complainTx.tx
+        );
+        await truffleAssert.eventEmitted(
+          internalComplain,
+          'LogVoucherComplain',
+          (ev) => {
+            return ev._tokenIdVoucher.toString() == voucherID;
+          }
+        );
+      });
+
+      it('[COMMIT->EXPIRY TRIGGERED->CANCEL->COMPLAIN] Buyer should be able to complain within the complain period after expiry triggered and seller cancels', async () => {
+        const ONE_WEEK = 7 * constants.SECONDS_IN_DAY;
+        await contractVoucherKernel.setComplainPeriod(ONE_WEEK);
+        await contractVoucherKernel.setCancelFaultPeriod(ONE_WEEK);
+
+        const voucherID = await utils.commitToBuy(
+          users.buyer,
+          users.seller,
+          TOKEN_SUPPLY_ID
+        );
+
+        await timemachine.advanceTimeSeconds(ONE_WEEK);
+
+        let expiryTx = await contractVoucherKernel.triggerExpiration(voucherID);
+
+        await truffleAssert.eventEmitted(
+          expiryTx,
+          'LogExpirationTriggered',
+          (ev) => {
+            return ev._triggeredBy === users.deployer.address;
+          }
+        );
+
+        let cancelTx = await utils.cancel(voucherID, users.seller.address);
+
+        const internalCancel = await truffleAssert.createTransactionResult(
+          contractVoucherKernel,
+          cancelTx.tx
+        );
+        await truffleAssert.eventEmitted(
+          internalCancel,
+          'LogVoucherFaultCancel',
+          (ev) => {
+            return ev._tokenIdVoucher.toString() == voucherID;
+          }
+        );
+
+        let complainTx = await utils.complain(voucherID, users.buyer.address);
+
+        const internalComplain = await truffleAssert.createTransactionResult(
+          contractVoucherKernel,
+          complainTx.tx
+        );
+        await truffleAssert.eventEmitted(
+          internalComplain,
+          'LogVoucherComplain',
+          (ev) => {
+            return ev._tokenIdVoucher.toString() == voucherID;
+          }
+        );
+      });
+
+      it('[COMMIT->EXPIRY TRIGGERED->COMPLAIN->CANCEL] Seller should be able to cancel within the cancel period after expiry triggered and buyer complains', async () => {
+        const ONE_WEEK = 7 * constants.SECONDS_IN_DAY;
+        await contractVoucherKernel.setComplainPeriod(ONE_WEEK);
+        await contractVoucherKernel.setCancelFaultPeriod(ONE_WEEK);
+
+        const voucherID = await utils.commitToBuy(
+          users.buyer,
+          users.seller,
+          TOKEN_SUPPLY_ID
+        );
+
+        await timemachine.advanceTimeSeconds(ONE_WEEK);
+
+        let expiryTx = await contractVoucherKernel.triggerExpiration(voucherID);
+
+        await truffleAssert.eventEmitted(
+          expiryTx,
+          'LogExpirationTriggered',
+          (ev) => {
+            return ev._triggeredBy === users.deployer.address;
+          }
+        );
+
+        let complainTx = await utils.complain(voucherID, users.buyer.address);
+
+        const internalComplain = await truffleAssert.createTransactionResult(
+          contractVoucherKernel,
+          complainTx.tx
+        );
+        await truffleAssert.eventEmitted(
+          internalComplain,
+          'LogVoucherComplain',
+          (ev) => {
+            return ev._tokenIdVoucher.toString() == voucherID;
+          }
+        );
+
+        let cancelTx = await utils.cancel(voucherID, users.seller.address);
+
+        const internalCancel = await truffleAssert.createTransactionResult(
+          contractVoucherKernel,
+          cancelTx.tx
+        );
+        await truffleAssert.eventEmitted(
+          internalCancel,
+          'LogVoucherFaultCancel',
+          (ev) => {
+            return ev._tokenIdVoucher.toString() == voucherID;
+          }
         );
       });
     });

--- a/testHelpers/utils.js
+++ b/testHelpers/utils.js
@@ -460,19 +460,21 @@ class Utils {
   }
 
   async refund(voucherID, buyer) {
-    await this.contractBSNRouter.refund(voucherID, {from: buyer});
+    return await this.contractBSNRouter.refund(voucherID, {from: buyer});
   }
 
   async redeem(voucherID, buyer) {
-    await this.contractBSNRouter.redeem(voucherID, {from: buyer});
+    return await this.contractBSNRouter.redeem(voucherID, {from: buyer});
   }
 
   async complain(voucherID, buyer) {
-    await this.contractBSNRouter.complain(voucherID, {from: buyer});
+    return await this.contractBSNRouter.complain(voucherID, {from: buyer});
   }
 
   async cancel(voucherID, seller) {
-    await this.contractBSNRouter.cancelOrFault(voucherID, {from: seller});
+    return await this.contractBSNRouter.cancelOrFault(voucherID, {
+      from: seller,
+    });
   }
 
   async finalize(voucherID, deployer) {


### PR DESCRIPTION
This PR sets `complainPeriodStart` on expired voucher, right after seller triggers CancelOrFault. Tests for this particular scenario as long with the [other mentioned flows](https://app.asana.com/0/1199560399769920/1200552404312078) (from the screenshot) from the UAT were added