### PR TITLE
[ADD] Repo CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These are the default owners of the repo
+*   @bosonprotocol/code-reviewers
+
+# Anything else added after this line will take precedence
+


### PR DESCRIPTION
@thecryptofruit the Team needs `Write` access, not `Triage` then the feature can be enabled in the branch protection section.