### PR TITLE
Add slither to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ At a minimum, you'll need:
 * Bundler (> 2)
 * Git
 * direnv
+* Docker
 
 For instructions on how to get set up with these specific versions:
 * See the [OS X guide](docs/setup/osx.md) if you are on a Mac.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ To compile the contracts:
 ./go contracts:compile
 ```
 
+To execute slither for the contracts:
+
+```shell script
+./go contracts:slither
+```
+
 ---
 ### Run
 To deploy instances of the contracts for local development without prior knowledge to Hardhat, first copy .env.example to .env and run the following command:

--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,7 @@ task :build => [
     :"contracts:compile",
     :"contracts:lint",
     :"contracts:format",
+    :"contracts:slither",
     :"tests:lint",
     :"tests:format"
 ]
@@ -24,7 +25,6 @@ task :build_fix => [
     :"contracts:compile",
     :"contracts:lint_fix",
     :"contracts:format_fix",
-    :"contracts:slither",
     :"tests:lint_fix",
     :"tests:format_fix"
 ]

--- a/Rakefile
+++ b/Rakefile
@@ -24,6 +24,7 @@ task :build_fix => [
     :"contracts:compile",
     :"contracts:lint_fix",
     :"contracts:format_fix",
+    :"contracts:slither",
     :"tests:lint_fix",
     :"tests:format_fix"
 ]
@@ -69,6 +70,11 @@ namespace :contracts do
   desc "Format & fix all contracts"
   task :format_fix => [:'dependencies:install'] do
     sh('npm', 'run', 'contracts:format-fix')
+  end
+
+  desc "Execute static analysis framework : Slither"
+  task :slither => [:'dependencies:install'] do
+    sh('./scripts/slither.sh')
   end
 end
 

--- a/docs/setup/linux.md
+++ b/docs/setup/linux.md
@@ -82,3 +82,9 @@ and use `rbenv init - zsh`.
 
 Note: if you use Fedora, see installation instructions at 
 [Installing Ruby and Rails with rbenv](https://developer.fedoraproject.org/start/sw/web-app/rails.html).
+
+### Docker
+
+Please visit [Install Docker Engine on Ubuntu](https://docs.docker.com/engine/install/ubuntu/) to follow instructions on how to install Docker on Ubuntu.
+
+Note: if you use Fedora, see installation instructions at [Install Docker Engine on Fedora](https://docs.docker.com/engine/install/fedora/).

--- a/docs/setup/osx.md
+++ b/docs/setup/osx.md
@@ -77,3 +77,7 @@ gem install bundler
 
 Note: if you use bash instead of zsh, change `~/.zshrc` above to `~/.bashrc`
 and use `rbenv init - bash`.
+
+### Docker
+
+Please visit https://docs.docker.com/desktop/mac/install/ to follow instructions on how to install Docker on your Mac.

--- a/scripts/slither.sh
+++ b/scripts/slither.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if ! docker info > /dev/null 2>&1; then
+  echo "This script uses docker, and it isn't running - please start docker and try again!"
+  exit 1
+fi
+
+docker run --rm -v "$PWD":/share -it --workdir=/share trailofbits/eth-security-toolbox@sha256:7127d551cec947a053a2979d90a018db45ab7679afce3915c232cfef9a41e0c4 -c 'solc-select 0.7.6 && slither .'
+
+exit 0 # Everything executed successfully without errors. Let's continue with the build now.


### PR DESCRIPTION
This PR adds `slither` static analysis tool into the build.

# Dependency:
Docker must be installed on your Mac / Linux.

# How to run slither.
1. You can run it when creating a build as `./go build`.
2. Alternatively, You can also run it as `./go contracts:slither`.

