### PR TITLE
Silence eslint issues

### DIFF
--- a/test/12_conditional_commit.ts
+++ b/test/12_conditional_commit.ts
@@ -1,5 +1,5 @@
 import {ethers} from 'hardhat';
-import {Signer, ContractFactory, Contract, Wallet, BigNumber} from 'ethers';
+import {Signer, ContractFactory, Contract, BigNumber} from 'ethers';
 import {assert, expect, use} from 'chai';
 import {ecsign} from 'ethereumjs-util';
 import constants from '../testHelpers/constants';

--- a/test/12_conditional_commit.ts
+++ b/test/12_conditional_commit.ts
@@ -1,6 +1,6 @@
 import {ethers} from 'hardhat';
 import {Signer, ContractFactory, Contract, BigNumber} from 'ethers';
-import {assert, expect, use} from 'chai';
+import {assert, expect} from 'chai';
 import {ecsign} from 'ethereumjs-util';
 import constants from '../testHelpers/constants';
 import Users from '../testHelpers/users';

--- a/test/8_token_wrappers.ts
+++ b/test/8_token_wrappers.ts
@@ -1,7 +1,7 @@
 import {ethers} from 'hardhat';
 import {ContractFactory, Contract, Wallet, BigNumber} from 'ethers';
 import {waffle} from 'hardhat';
-import {assert, expect} from 'chai';
+import {expect} from 'chai';
 import {ecsign} from 'ethereumjs-util';
 import constants from '../testHelpers/constants';
 import {advanceTimeSeconds} from '../testHelpers/timemachine';

--- a/testHelpers/permitUtilsDAI.ts
+++ b/testHelpers/permitUtilsDAI.ts
@@ -44,6 +44,7 @@ export async function getApprovalDigestDAI(
   );
 }
 
+/* eslint-disable @typescript-eslint/no-unused-vars */
 export function getDomainSeparator(name: string, tokenAddress: string): string {
   //Hardcoding he DOMAIN_SEPARATOR hash to the one for the DAI token on Rinkeby.
   //Retrieved from Etherscan. It doesn't seem possible to generat the correct
@@ -77,3 +78,4 @@ export function getDomainSeparator(name: string, tokenAddress: string): string {
   //This is the DOMAIN_SEPARATOR hash of the DAI token on Rinkeby
   return '0x47d45448983c2e0e8e44c1742c08102651ce6a7c04b99128a81d918f2b204f74';
 }
+/* eslint-enable @typescript-eslint/no-unused-vars */


### PR DESCRIPTION
This PR removes the eslint warnings found when we run `./go tests:lint`.

<img width="2420" alt="Screenshot 2021-10-04_17-48-01-137" src="https://user-images.githubusercontent.com/91169722/135851065-63594b24-adc1-45fa-b0d1-7effba96faf1.png">
