### PR TITLE
Implement safeMint for ERC721 in ERC1155ERC721.sol

### DIFF
--- a/contracts/ERC1155ERC721.sol
+++ b/contracts/ERC1155ERC721.sol
@@ -357,6 +357,29 @@ contract ERC1155ERC721 is IERC1155ERC721, Ownable, ReentrancyGuard {
     }
 
     /**
+     * @notice Check successful mint if recipient is a contract
+     * @dev ERC-721
+     * @param _to       Address of recipient
+     * @param _tokenId  ID of the token
+     */
+    function _doSafeMintAcceptanceCheck(
+        address _to,
+        uint256 _tokenId
+    ) internal {
+        if (_to.isContract()) {
+            require(
+                IERC721Receiver(_to).onERC721Received(
+                    address(0),
+                    _to,
+                    _tokenId,
+                    ""
+                ) == IERC721Receiver(_to).onERC721Received.selector,
+                "UNSUPPORTED_ERC721_RECEIVED"
+            );
+        }
+    }
+
+    /**
      * @notice Check successful transfer if recipient is a contract
      * @dev ERC-1155
      * @param _operator The operator of the transfer
@@ -587,6 +610,8 @@ contract ERC1155ERC721 is IERC1155ERC721, Ownable, ReentrancyGuard {
         balance721[_to]++;
 
         emit Transfer(address(0), _to, _tokenId);
+
+        _doSafeMintAcceptanceCheck(_to, _tokenId);
     }
 
     /**

--- a/contracts/ERC1155ERC721.sol
+++ b/contracts/ERC1155ERC721.sol
@@ -154,17 +154,12 @@ contract ERC1155ERC721 is IERC1155ERC721, Ownable, ReentrancyGuard {
     ) public override {
         transferFrom(_from, _to, _tokenId);
 
-        if (_to.isContract()) {
-            require(
-                IERC721Receiver(_to).onERC721Received(
-                    _from,
-                    _to,
-                    _tokenId,
-                    _data
-                ) == IERC721Receiver(_to).onERC721Received.selector,
-                "UNSUPPORTED_ERC721_RECEIVED"
-            );
-        }
+        _doSafeTransferAcceptanceCheck(
+            address(0),
+            _to,
+            _tokenId,
+            _data
+        );
     }
 
     /**
@@ -327,6 +322,7 @@ contract ERC1155ERC721 is IERC1155ERC721, Ownable, ReentrancyGuard {
     /**
      * @notice Check successful transfer if recipient is a contract
      * @dev ERC-1155
+     * https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v4.4.0-rc.0/contracts/token/ERC1155/ERC1155.sol
      * @param _operator The operator of the transfer
      * @param _from     Address of sender
      * @param _to       Address of recipient
@@ -343,45 +339,54 @@ contract ERC1155ERC721 is IERC1155ERC721, Ownable, ReentrancyGuard {
         bytes memory _data
     ) internal {
         if (_to.isContract()) {
-            require(
-                IERC1155Receiver(_to).onERC1155Received(
-                    _operator,
-                    _from,
-                    _tokenId,
-                    _value,
-                    _data
-                ) == IERC1155Receiver(_to).onERC1155Received.selector,
-                "NOT_SUPPORTED"
-            );
+            try IERC1155Receiver(_to).onERC1155Received(_operator, _from, _tokenId, _value, _data) returns (bytes4 response) {
+                if (response != IERC1155Receiver.onERC1155Received.selector) {
+                    revert("ERC1155: ERC1155Receiver rejected tokens");
+                }
+            } catch Error(string memory reason) {
+                revert(reason);
+            } catch {
+                revert("ERC1155: transfer to non ERC1155Receiver implementer");
+            }
         }
     }
 
     /**
      * @notice Check successful mint if recipient is a contract
      * @dev ERC-721
+     * https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v4.4.0-rc.0/contracts/token/ERC721/ERC721.sol
+     * @param _from     Address of sender
      * @param _to       Address of recipient
      * @param _tokenId  ID of the token
+     * @param _data     Optional data
      */
-    function _doSafeMintAcceptanceCheck(
+    function _doSafeTransferAcceptanceCheck(
+        address _from,
         address _to,
-        uint256 _tokenId
-    ) internal {
+        uint256 _tokenId,
+        bytes memory _data
+    ) internal returns (bool) {
         if (_to.isContract()) {
-            require(
-                IERC721Receiver(_to).onERC721Received(
-                    address(0),
-                    _to,
-                    _tokenId,
-                    ""
-                ) == IERC721Receiver(_to).onERC721Received.selector,
-                "UNSUPPORTED_ERC721_RECEIVED"
-            );
+            try IERC721Receiver(_to).onERC721Received(_msgSender(), _from, _tokenId, _data) returns (bytes4 retval) {
+                return retval == IERC721Receiver.onERC721Received.selector;
+            } catch (bytes memory reason) {
+                if (reason.length == 0) {
+                    revert("ERC721: transfer to non ERC721Receiver implementer");
+                } else {
+                    assembly {
+                        revert(add(32, reason), mload(reason))
+                    }
+                }
+            }
+        } else {
+            return true;
         }
     }
 
     /**
      * @notice Check successful transfer if recipient is a contract
      * @dev ERC-1155
+     * https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v4.4.0-rc.0/contracts/token/ERC1155/ERC1155.sol
      * @param _operator The operator of the transfer
      * @param _from     Address of sender
      * @param _to       Address of recipient
@@ -398,16 +403,17 @@ contract ERC1155ERC721 is IERC1155ERC721, Ownable, ReentrancyGuard {
         bytes memory _data
     ) internal {
         if (_to.isContract()) {
-            require(
-                IERC1155Receiver(_to).onERC1155BatchReceived(
-                    _operator,
-                    _from,
-                    _tokenIds,
-                    _values,
-                    _data
-                ) == IERC1155Receiver(_to).onERC1155BatchReceived.selector,
-                "NOT_SUPPORTED"
-            );
+            try IERC1155Receiver(_to).onERC1155BatchReceived(_operator, _from, _tokenIds, _values, _data) returns (
+                bytes4 response
+            ) {
+                if (response != IERC1155Receiver.onERC1155BatchReceived.selector) {
+                    revert("ERC1155: ERC1155Receiver rejected tokens");
+                }
+            } catch Error(string memory reason) {
+                revert(reason);
+            } catch {
+                revert("ERC1155: transfer to non ERC1155Receiver implementer");
+            }
         }
     }
 
@@ -605,13 +611,17 @@ contract ERC1155ERC721 is IERC1155ERC721, Ownable, ReentrancyGuard {
             owners721[_tokenId] == address(0),
             "ERC721: token already minted"
         );
-
         owners721[_tokenId] = _to;
         balance721[_to]++;
 
         emit Transfer(address(0), _to, _tokenId);
 
-        _doSafeMintAcceptanceCheck(_to, _tokenId);
+        require(_doSafeTransferAcceptanceCheck(
+            address(0),
+            _to,
+            _tokenId,
+            ""
+        ), "ERC721: transfer to non ERC721Receiver implementer");
     }
 
     /**

--- a/test/6_erc1155721.ts
+++ b/test/6_erc1155721.ts
@@ -1748,7 +1748,7 @@ describe('ERC1155ERC721', () => {
         assert.equal(balanceOfBuyer.toString(), expectedBalance.toString());
       });
 
-      it('[NEGATIVE][mint] it should not be able to mint a token to a contract that cannot receive it', async () => {
+      it('[NEGATIVE][mint] it should not be able to mint a token to a receiver that cannot receive it', async () => {
         // spoofing the VoucherKernel address here because the function is being called directly instead of via the VoucherKernel contract
         await contractERC1155ERC721.setVoucherKernelAddress(
           users.deployer.address

--- a/test/6_erc1155721.ts
+++ b/test/6_erc1155721.ts
@@ -1748,6 +1748,21 @@ describe('ERC1155ERC721', () => {
         assert.equal(balanceOfBuyer.toString(), expectedBalance.toString());
       });
 
+      it('[NEGATIVE][mint] it should not be able to mint a token to a contract that cannot receive it', async () => {
+        // spoofing the VoucherKernel address here because the function is being called directly instead of via the VoucherKernel contract
+        await contractERC1155ERC721.setVoucherKernelAddress(
+          users.deployer.address
+        );
+
+        const tokenIdForMint = 123;
+        await expect(
+          contractERC1155ERC721.functions[fnSignatures.mint721](
+            contractCashier.address,
+            tokenIdForMint
+          )
+        ).to.be.revertedWith(revertReasons.FN_SELECTOR_NOT_RECOGNIZED);
+      });
+
       it('[NEGATIVE][mint] must fail: unauthorized minting ERC-721', async () => {
         await expect(
           contractERC1155ERC721.functions[fnSignatures.mint721](

--- a/test/6_erc1155721.ts
+++ b/test/6_erc1155721.ts
@@ -486,7 +486,7 @@ describe('ERC1155ERC721', () => {
             constants.QTY_10,
             users.seller.signer
           )
-        ).to.be.revertedWith(revertReasons.FN_SELECTOR_NOT_RECOGNIZED);
+        ).to.be.revertedWith(revertReasons.NON_ERC1155RECEIVER);
       });
 
       it('[safeBatchTransfer1155] Should be able to safely batch transfer to EOA', async () => {
@@ -673,7 +673,7 @@ describe('ERC1155ERC721', () => {
             [constants.QTY_10],
             users.seller.signer
           )
-        ).to.be.revertedWith(revertReasons.FN_SELECTOR_NOT_RECOGNIZED);
+        ).to.be.revertedWith(revertReasons.NON_ERC1155RECEIVER);
       });
 
       it('[NEGATIVE][safeBatchTransfer1155] Should revert if attacker tries to transfer batch', async () => {
@@ -817,7 +817,7 @@ describe('ERC1155ERC721', () => {
             constants.QTY_10,
             ethers.utils.formatBytes32String('0x0')
           )
-        ).to.be.revertedWith(revertReasons.FN_SELECTOR_NOT_RECOGNIZED);
+        ).to.be.revertedWith(revertReasons.NON_ERC1155RECEIVER);
       });
 
       it('[NEGATIVE][mint] must fail: unauthorized minting ERC-1155', async () => {
@@ -1042,7 +1042,7 @@ describe('ERC1155ERC721', () => {
             [constants.QTY_10],
             ethers.utils.formatBytes32String('0x0')
           )
-        ).to.be.revertedWith(revertReasons.FN_SELECTOR_NOT_RECOGNIZED);
+        ).to.be.revertedWith(revertReasons.NON_ERC1155RECEIVER);
       });
 
       it('[NEGATIVE][mintBatch] Should revert when _account is a zero address', async () => {
@@ -1482,7 +1482,7 @@ describe('ERC1155ERC721', () => {
             erc721,
             users.buyer.signer
           )
-        ).to.be.revertedWith(revertReasons.FN_SELECTOR_NOT_RECOGNIZED);
+        ).to.be.revertedWith(revertReasons.NON_ERC721RECEIVER);
       });
 
       it('[NEGATIVE][safeTransfer721] Attacker should not be able to transfer erc721', async () => {
@@ -1760,7 +1760,7 @@ describe('ERC1155ERC721', () => {
             contractCashier.address,
             tokenIdForMint
           )
-        ).to.be.revertedWith(revertReasons.FN_SELECTOR_NOT_RECOGNIZED);
+        ).to.be.revertedWith(revertReasons.NON_ERC721RECEIVER);
       });
 
       it('[NEGATIVE][mint] must fail: unauthorized minting ERC-721', async () => {

--- a/testHelpers/revertReasons.ts
+++ b/testHelpers/revertReasons.ts
@@ -54,4 +54,6 @@ export default {
   UNSUPPORTED_TOKEN: 'UNSUPPORTED_TOKEN',
   EOA: 'Transaction reverted: function call to a non-contract account',
   INVALID_VALUE: 'INVALID_VALUE',
+  NON_ERC721RECEIVER: 'ERC721: transfer to non ERC721Receiver implementer',
+  NON_ERC1155RECEIVER: 'ERC1155: transfer to non ERC1155Receiver implementer',
 };


### PR DESCRIPTION
In this PR, I am restricting the mint of ERC-721 to a receiver that does not support it.