### PR TITLE
Don't run GHA on draft PRs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,4 +32,3 @@ VOUCHERS_CONTRACT_URI=https://metadata.boson.example/voucher/contract.json
 
 # Max tip in gwei - use "Fastest" setting from: https://www.etherchain.org/api/gasPriceOracle
 MAX_TIP = 13.1
-

--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,4 @@ VOUCHERS_CONTRACT_URI=https://metadata.boson.example/voucher/contract.json
 
 # Max tip in gwei - use "Fastest" setting from: https://www.etherchain.org/api/gasPriceOracle
 MAX_TIP = 13.1
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     env:
       PROTOCOL_DEPLOYER_PRIVATE_KEY: 123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234
       CC_TOKEN_DEPLOYER_PRIVATE_KEY: 123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234
@@ -31,6 +32,7 @@ jobs:
   test:
     needs: build
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     env:
       PROTOCOL_DEPLOYER_PRIVATE_KEY: 123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234
       CC_TOKEN_DEPLOYER_PRIVATE_KEY: 123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234
@@ -54,6 +56,7 @@ jobs:
 
   snyk:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities


### PR DESCRIPTION
This PR skips Build/Test/Synk when PR is in `Draft` status.

### Steps to Verify:
1. This Commit at https://github.com/bosonprotocol/contracts/pull/273/commits/1c17c96b0bef13a00d3de508d660b146ac908b13 Skipped the Build/Test/Synk steps when the PR was in draft status.
---
<img width="1732" alt="Screenshot 2021-11-08_18-02-06-503" src="https://user-images.githubusercontent.com/91169722/140743097-85fd76c3-0542-4789-b145-61a148ac337f.png">

---

2. Once the PR is marked as ready for review, the next commit at https://github.com/bosonprotocol/contracts/pull/273/commits/75924964cde1e5f548c3ae68b4dc79d379b0abbd runs all the CI steps as intended.