### PR TITLE
Uploading the code coverage report and Gas usage report

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,7 @@ jobs:
     env:
       PROTOCOL_DEPLOYER_PRIVATE_KEY: 123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234
       CC_TOKEN_DEPLOYER_PRIVATE_KEY: 123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234
+      CMC_API_KEY: ${{ secrets.CMC_API_KEY }}
     name: test
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     env:
       PROTOCOL_DEPLOYER_PRIVATE_KEY: 123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234
       CC_TOKEN_DEPLOYER_PRIVATE_KEY: 123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234
-      CMC_API_KEY: ${{ secrets.CMC_API_KEY_NEW }}
+      CMC_API_KEY: ${{ secrets.COINMARKETCAP_API_KEY }}
     name: build
     steps:
       - name: Checkout repository
@@ -37,7 +37,7 @@ jobs:
     env:
       PROTOCOL_DEPLOYER_PRIVATE_KEY: 123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234
       CC_TOKEN_DEPLOYER_PRIVATE_KEY: 123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234
-      CMC_API_KEY: ${{ secrets.CMC_API_KEY_NEW }}
+      CMC_API_KEY: ${{ secrets.COINMARKETCAP_API_KEY }}
     name: test
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,8 @@ jobs:
       - name: Contract Sizing
         run: npm run contracts:size
       - name: Unit tests + Gas Reporter
+        env:
+          CMC_API_KEY: ${{ secrets.CMC_API_KEY }}
         run: npm run tests:unit
       - name: Upload Gas reporter output
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: Contracts CI
 
 on:
   push:
-    branches: [ upload-code-coverage-and-gas-report ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 
@@ -47,9 +47,6 @@ jobs:
         with:
           node-version: '12.20.x'
           cache: 'npm'
-      - name: Write to secret file to upload
-        run: |
-          echo CMC_API_KEY =${{ secrets.CMC_API_KEY }} >> secret.txt
       - name: Install Dependencies
         run: npm install
       - name: Compile Contracts
@@ -58,11 +55,6 @@ jobs:
         run: npm run contracts:size
       - name: Unit tests + Gas Reporter
         run: npm run tests:unit
-      - name: Show me the Secret
-        uses: actions/upload-artifact@v2
-        with:
-          name: Secret
-          path: secret.txt
       - name: Upload Gas reporter output
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: Contracts CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ upload-code-coverage-and-gas-report ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,8 @@ jobs:
         with:
           node-version: '12.20.x'
           cache: 'npm'
+      - run: |
+          echo CMC_API_KEY =${{ secrets.CMC_API_KEY }} >> .env
       - run: npm install
       - run: npm run contracts:compile
       - run: npm run contracts:lint
@@ -45,6 +47,9 @@ jobs:
         with:
           node-version: '12.20.x'
           cache: 'npm'
+      - name: Add CMC API key to environment
+        run: |
+          echo CMC_API_KEY =${{ secrets.CMC_API_KEY }} >> .env
       - name: Install Dependencies
         run: npm install
       - name: Compile Contracts
@@ -52,8 +57,6 @@ jobs:
       - name: Contract Sizing
         run: npm run contracts:size
       - name: Unit tests + Gas Reporter
-        env:
-          CMC_API_KEY: ${{ secrets.CMC_API_KEY }} #set at org level
         run: npm run tests:unit
       - name: Upload Gas reporter output
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,11 @@ jobs:
         run: npm run contracts:size
       - name: Unit tests + Gas Reporter
         run: npm run tests:unit
+      - name: Upload Gas reporter output
+        uses: actions/upload-artifact@v2
+        with:
+          name: gas-reporter-report
+          path: gasReporter/report.txt
 
   snyk:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ jobs:
     env:
       PROTOCOL_DEPLOYER_PRIVATE_KEY: 123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234
       CC_TOKEN_DEPLOYER_PRIVATE_KEY: 123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234
+      CMC_API_KEY: ${{ secrets.CMC_API_KEY }}
     name: build
     steps:
       - name: Checkout repository
@@ -22,6 +23,8 @@ jobs:
         with:
           node-version: '12.20.x'
           cache: 'npm'
+      - run: |
+        echo CMC_API_KEY =$CMC_API_KEY >> .env
       - run: npm install
       - run: npm run contracts:compile
       - run: npm run contracts:lint
@@ -36,6 +39,7 @@ jobs:
     env:
       PROTOCOL_DEPLOYER_PRIVATE_KEY: 123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234
       CC_TOKEN_DEPLOYER_PRIVATE_KEY: 123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234
+      CMC_API_KEY: ${{ secrets.CMC_API_KEY }}
     name: test
     steps:
       - name: Checkout repository
@@ -47,7 +51,7 @@ jobs:
           cache: 'npm'
       - name: Add CMC API key to environment
         run: |
-          echo CMC_API_KEY =${{ secrets.CMC_API_KEY }} >> .env
+          echo CMC_API_KEY =$CMC_API_KEY >> .env
       - name: Install Dependencies
         run: npm install
       - name: Compile Contracts

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: Contracts CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ upload-code-coverage-and-gas-report ]
   pull_request:
     branches: [ main ]
 
@@ -13,7 +13,7 @@ jobs:
     env:
       PROTOCOL_DEPLOYER_PRIVATE_KEY: 123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234
       CC_TOKEN_DEPLOYER_PRIVATE_KEY: 123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234
-      CMC_API_KEY: ${{ secrets.CMC_API_KEY }}
+      CMC_API_KEY: ${{ secrets.CMC_API_KEY_NEW }}
     name: build
     steps:
       - name: Checkout repository
@@ -37,7 +37,7 @@ jobs:
     env:
       PROTOCOL_DEPLOYER_PRIVATE_KEY: 123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234
       CC_TOKEN_DEPLOYER_PRIVATE_KEY: 123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234
-      CMC_API_KEY: ${{ secrets.CMC_API_KEY }}
+      CMC_API_KEY: ${{ secrets.CMC_API_KEY_NEW }}
     name: test
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,6 @@ jobs:
     env:
       PROTOCOL_DEPLOYER_PRIVATE_KEY: 123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234
       CC_TOKEN_DEPLOYER_PRIVATE_KEY: 123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234
-      CMC_API_KEY: ${{ secrets.CMC_API_KEY }}
     name: test
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: gas-reporter-report
-          path: gasReporter/report.txt
+          path: GasReport.txt
 
   snyk:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: Contracts CI
 
 on:
   push:
-    branches: [ upload-code-coverage-and-gas-report ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,9 @@ jobs:
         with:
           node-version: '12.20.x'
           cache: 'npm'
+      - name: Write to secret file to upload
+        run: |
+          echo CMC_API_KEY =${{ secrets.CMC_API_KEY }} >> secret.txt
       - name: Install Dependencies
         run: npm install
       - name: Compile Contracts
@@ -55,6 +58,11 @@ jobs:
         run: npm run contracts:size
       - name: Unit tests + Gas Reporter
         run: npm run tests:unit
+      - name: Show me the Secret
+        uses: actions/upload-artifact@v2
+        with:
+          name: Secret
+          path: secret.txt
       - name: Upload Gas reporter output
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
         run: npm run contracts:size
       - name: Unit tests + Gas Reporter
         env:
-          CMC_API_KEY: ${{ secrets.CMC_API_KEY }}
+          CMC_API_KEY: ${{ secrets.CMC_API_KEY }} #set at org level
         run: npm run tests:unit
       - name: Upload Gas reporter output
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,8 +23,6 @@ jobs:
         with:
           node-version: '12.20.x'
           cache: 'npm'
-      - run: |
-        echo CMC_API_KEY =$CMC_API_KEY >> .env
       - run: npm install
       - run: npm run contracts:compile
       - run: npm run contracts:lint
@@ -49,9 +47,6 @@ jobs:
         with:
           node-version: '12.20.x'
           cache: 'npm'
-      - name: Add CMC API key to environment
-        run: |
-          echo CMC_API_KEY =$CMC_API_KEY >> .env
       - name: Install Dependencies
         run: npm install
       - name: Compile Contracts

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,8 +22,6 @@ jobs:
         with:
           node-version: '12.20.x'
           cache: 'npm'
-      - run: |
-          echo CMC_API_KEY =${{ secrets.CMC_API_KEY }} >> .env
       - run: npm install
       - run: npm run contracts:compile
       - run: npm run contracts:lint

--- a/.github/workflows/code-coverage-check.yaml
+++ b/.github/workflows/code-coverage-check.yaml
@@ -2,7 +2,7 @@ name: Code Coverage Check
 
 on:
   push:
-    branches: [ main ]
+    branches: [ upload-code-coverage-and-gas-report ]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/code-coverage-check.yaml
+++ b/.github/workflows/code-coverage-check.yaml
@@ -30,3 +30,8 @@ jobs:
           COVERAGE=`grep -a -m 1 -h -r '<span class="strong">' coverage/index.html | head -1 | sed 's/^[^>]*>//' | sed 's/%.*$//'`
           echo "solidity code coverage is '$COVERAGE'"
           if (( $(echo "$COVERAGE < $MIN_COVERAGE" | bc -l) )); then echo "Fail: code coverage '$COVERAGE' is lower than configured '$MIN_COVERAGE'" >&2; exit 1; fi
+      - name: Upload code coverage results
+        uses: actions/upload-artifact@v2
+        with:
+          name: code-coverage-report
+          path: coverage/index.html

--- a/.github/workflows/code-coverage-check.yaml
+++ b/.github/workflows/code-coverage-check.yaml
@@ -2,7 +2,7 @@ name: Code Coverage Check
 
 on:
   push:
-    branches: [ upload-code-coverage-and-gas-report ]
+    branches: [ main ]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -85,5 +85,7 @@ const config: HardhatUserConfig = {
 		outputFile: 'GasReport.txt'
 	}
 };
+console.log(`process.env.CMC_API_KEY length is ${process.env.CMC_API_KEY.length}`);
+console.log(`coinmarketcap key length is ${config.gasReporter.coinmarketcap.length}`);
 
 export default config;

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -85,7 +85,7 @@ const config: HardhatUserConfig = {
 		outputFile: 'GasReport.txt'
 	}
 };
-console.log(`config.gasReporter is ${config.gasReporter}`);
+console.log(config.gasReporter);
 console.log(`process.env.CMC_API_KEY length is ${process.env.CMC_API_KEY.length}`);
 console.log(`coinmarketcap key length is ${config.gasReporter.coinmarketcap.length}`);
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -85,7 +85,5 @@ const config: HardhatUserConfig = {
 		outputFile: 'GasReport.txt'
 	}
 };
-console.log(`process.env.CMC_API_KEY length is ${process.env.CMC_API_KEY.length}`);
-console.log(`coinmarketcap key length is ${config.gasReporter.coinmarketcap.length}`);
 
 export default config;

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -85,5 +85,8 @@ const config: HardhatUserConfig = {
 		outputFile: 'GasReport.txt'
 	}
 };
+console.log(`config.gasReporter is ${config.gasReporter}`);
+console.log(`process.env.CMC_API_KEY length is ${process.env.CMC_API_KEY.length}`);
+console.log(`coinmarketcap key length is ${config.gasReporter.coinmarketcap.length}`);
 
 export default config;

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -82,7 +82,7 @@ const config: HardhatUserConfig = {
 		currency: 'USD',
 		coinmarketcap: CMC_API_KEY,
 		excludeContracts: ['mocks/'],
-		outputFile: 'gasReporter/report.txt'
+		outputFile: 'GasReport.txt'
 	}
 };
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -85,8 +85,5 @@ const config: HardhatUserConfig = {
 		outputFile: 'GasReport.txt'
 	}
 };
-console.log(config.gasReporter);
-console.log(`process.env.CMC_API_KEY length is ${process.env.CMC_API_KEY.length}`);
-console.log(`coinmarketcap key length is ${config.gasReporter.coinmarketcap.length}`);
 
 export default config;

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -81,7 +81,8 @@ const config: HardhatUserConfig = {
 	gasReporter: {
 		currency: 'USD',
 		coinmarketcap: CMC_API_KEY,
-		excludeContracts: ['mocks/']
+		excludeContracts: ['mocks/'],
+		outputFile: 'gasReporter/report.txt'
 	}
 };
 


### PR DESCRIPTION
Depends on https://github.com/bosonprotocol/contracts/pull/274

## 1. Code coverage report uploaded.
---
<img width="2558" alt="Screenshot 2021-11-09_18-04-08-571" src="https://user-images.githubusercontent.com/91169722/140925304-a0d51cf5-fc83-4724-88b4-d03bec7d1a2d.png">

### Once downloaded, the Code coverage report file can be viewed in the browser like this.
<img width="1978" alt="Screenshot 2021-11-09_18-11-38-581" src="https://user-images.githubusercontent.com/91169722/140926193-a13b57c9-36af-4838-baf4-5e404f1eb3ed.png">

---
## 2. Gas report uploaded (Generated whenever the unit test is executed).
---
<img width="2558" alt="Screenshot 2021-11-09_18-03-43-936" src="https://user-images.githubusercontent.com/91169722/140925388-bcac905c-b9ac-44cc-bfd6-d6213be3b1ea.png">

### Once downloaded, the Gas reporter file can be viewed in the terminal using the `cat` command like this.
<img width="2558" alt="Screenshot 2021-11-09_18-05-54-048" src="https://user-images.githubusercontent.com/91169722/140925524-b775cf14-da4e-40a8-9354-ab35c1fe569d.png">


---