### PR TITLE
Update deployment.md

### DIFF
--- a/docs/contracts/deployment.md
+++ b/docs/contracts/deployment.md
@@ -19,7 +19,7 @@ This page lists the most recent versions of the Boson Protocol contracts on the 
 
 ## [v1.0.0-rc.3](https://github.com/bosonprotocol/contracts/releases/tag/v1.0.0-rc.3) Contracts are deployed to Ropsten testnet
 
-| Contract Name | Address
+| Contract Name | Address |
 | ----------- | ----------- |
 | $BOSON Token Contract Address | [`0xf47E4fd9d2eBd6182F597eE12E487CcA37FC524c`](https://ropsten.etherscan.io/address/0xf47E4fd9d2eBd6182F597eE12E487CcA37FC524c#code) |
 | TokenRegistry | [`0x3652b1b62648060C80F1bf7aC017b91AB1986E0d`](https://ropsten.etherscan.io/address/0x3652b1b62648060C80F1bf7aC017b91AB1986E0d#code) | 

--- a/docs/contracts/deployment.md
+++ b/docs/contracts/deployment.md
@@ -1,30 +1,33 @@
 # Smart Contracts - Deployment
 
-This page lists the most uptodate versions of our contract on the various networks.
+This page lists the most recent versions of the Boson Protocol contracts on the various networks.
 
-## 1.0.0 Contracts are deployed to Ethereum mainnet
-
-| Contract Name | Address |
-| ----------- | ----------- |
-| $BOSON Token Contract Address | 0xc477d038d5420c6a9e0b031712f61c5120090de9 |
-| TokenRegistry | 0xA939c19121DB32A37708E19B994ff02675e012fa |
-| VoucherSets | 0xc7Ce90B985CbD9b6D6daab012F2622e437A7101C |
-| Vouchers | 0x17053D2B8a4bEA8B878a99636E25B509e081e2e3 |
-| VoucherKernel | 0xAA10D375b2b61E99bdBA850550b71b26b1C45746 |
-| Cashier | 0x783A2e37C1C990435DEbBf3737d3e4E029F6AAe7 |
-| Boson Router | 0x48093736F038935C50DC587D14Ba8C7857683293 |
-| DaiTokenWrapper | 0x70d4De3E810084d78eB4D9df3832ce189962bDf8 |
-| Date | 0x691F21A5B65d76520a4E38e893c8aa28C920BBDf |
-| Erc1155NonTransferable (Quest NFTs for Conditional Commit) | 0xBAd188Ec8B4E168dF2a39C462A7293955EF04bf8 |
-
-
-## v0.1.0 Contracts are deployed on Rinkeby testnet
+## [v1.0.0](https://github.com/bosonprotocol/contracts/releases/tag/v1.0.0) Contracts are deployed to Ethereum mainnet
 
 | Contract Name | Address |
 | ----------- | ----------- |
-| $BOSON Token Contract Address | 0x1b48e27D7ABaDf2f5A5f14975Cb9D4E457dF5111 |
-| Boson Router Contract Address | 0x29C9361920785F4B2175Ba61c177cEdC6A99542A |
-| Cashier Contract Address | 0x0bfF7B7A04C1eB19DeA63f0FF4D884914edB61E8 |
-| VoucherKernel Contract Address | 0x82a33733c2f8696F7fd61D0874351cbb8Ea61EBc |
-| ERC1155ERC721 Contract Address | 0x654FA4C10C0F66c4D94B4AD458236A260888AB5a |
-| FundLimitsOracle Contract Address | 0x4d827187dD0df5bF02575d24E5586e765511596e |
+| $BOSON Token Contract Address | [`0xc477d038d5420c6a9e0b031712f61c5120090de9`](https://etherscan.io/address/0xc477d038d5420c6a9e0b031712f61c5120090de9#code) |
+| TokenRegistry | [`0xA939c19121DB32A37708E19B994ff02675e012fa`](https://etherscan.io/address/0xA939c19121DB32A37708E19B994ff02675e012fa#code) |
+| VoucherSets | [`0xc7Ce90B985CbD9b6D6daab012F2622e437A7101C`](https://etherscan.io/address/0xc7Ce90B985CbD9b6D6daab012F2622e437A7101C#code) |
+| Vouchers | [`0x17053D2B8a4bEA8B878a99636E25B509e081e2e3`](https://etherscan.io/address/0x17053D2B8a4bEA8B878a99636E25B509e081e2e3#code) |
+| VoucherKernel | [`0xAA10D375b2b61E99bdBA850550b71b26b1C45746`](https://etherscan.io/address/0xAA10D375b2b61E99bdBA850550b71b26b1C45746#code) |
+| Cashier | [`0x783A2e37C1C990435DEbBf3737d3e4E029F6AAe7`](https://etherscan.io/address/0x783A2e37C1C990435DEbBf3737d3e4E029F6AAe7#code) |
+| Boson Router | [`0x48093736F038935C50DC587D14Ba8C7857683293`](https://etherscan.io/address/0x48093736F038935C50DC587D14Ba8C7857683293#code) |
+| DaiTokenWrapper | [`0x70d4De3E810084d78eB4D9df3832ce189962bDf8`](https://etherscan.io/address/0x70d4De3E810084d78eB4D9df3832ce189962bDf8#code) |
+| Gate | [`0x691F21A5B65d76520a4E38e893c8aa28C920BBDf`](https://etherscan.io/address/0x691F21A5B65d76520a4E38e893c8aa28C920BBDf#code) |
+| Erc1155NonTransferable (Quest NFTs for Conditional Commit) | [`0xBAd188Ec8B4E168dF2a39C462A7293955EF04bf8`](https://etherscan.io/address/0xBAd188Ec8B4E168dF2a39C462A7293955EF04bf8#code) |
+
+## [v1.0.0-rc.3](https://github.com/bosonprotocol/contracts/releases/tag/v1.0.0-rc.3) Contracts are deployed to Ropsten testnet
+
+| Contract Name | Address
+| ----------- | ----------- |
+| $BOSON Token Contract Address | [`0xf47E4fd9d2eBd6182F597eE12E487CcA37FC524c`](https://ropsten.etherscan.io/address/0xf47E4fd9d2eBd6182F597eE12E487CcA37FC524c#code) |
+| TokenRegistry | [`0x3652b1b62648060C80F1bf7aC017b91AB1986E0d`](https://ropsten.etherscan.io/address/0x3652b1b62648060C80F1bf7aC017b91AB1986E0d#code) | 
+| VoucherSets | [`0x2911d858859c426Ccb85AB15FF76fA60f2Dcd35f`](https://ropsten.etherscan.io/address/0x2911d858859c426Ccb85AB15FF76fA60f2Dcd35f#code) | 
+| Vouchers | [`0xe2b1BE3B7c21f575944283773d1FC3EC95D44CfE`](https://ropsten.etherscan.io/address/0xe2b1BE3B7c21f575944283773d1FC3EC95D44CfE#code) | 
+| VoucherKernel | [`0x9A9EC4d45A8e0f805fBe39135710C3dF5e60d004`](https://ropsten.etherscan.io/address/0x9A9EC4d45A8e0f805fBe39135710C3dF5e60d004#code) | 
+| Cashier | [`0x7C4A3BA6FcEBE08970480b2d159d16e0CB401037`](https://ropsten.etherscan.io/address/0x7C4A3BA6FcEBE08970480b2d159d16e0CB401037#code) |
+| Boson Router | [`0x419E3F469f51648D0BC7395fafE8DE14b4Fe39A2`](https://ropsten.etherscan.io/address/0x419E3F469f51648D0BC7395fafE8DE14b4Fe39A2#code) |
+| DaiTokenWrapper | [`0xC408C90E87613bce96CD5461ECdC60C48579feC6`](https://ropsten.etherscan.io/address/0xC408C90E87613bce96CD5461ECdC60C48579feC6#code) |
+| Gate | [`0x42A26332c46186510213CD803f8E74aab6A69Fa8`](https://ropsten.etherscan.io/address/0x42A26332c46186510213CD803f8E74aab6A69Fa8#code) |
+| Erc1155NonTransferable (Quest NFTs for Conditional Commit) | [`0x8988071924a4c1529eB5361A3cf3791f48700058`](https://ropsten.etherscan.io/address/0x8988071924a4c1529eB5361A3cf3791f48700058#code) | 


### PR DESCRIPTION
* Edited mainnet table
  - Linked "v1.0.0" in section head to tag page on Github
  - Marked up addresses to show in code font with links to their verified Etherscan pages

* Added Ropsten table,
  - Linked "v1.0.0-rc.3" in section head to tag page on Github
  - Marked up addresses to show in code font with links to their verified Etherscan pages

* Rinkeby table
  - Stale, removed

* This fixes #278