### PR TITLE
Deploy mock token locally

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,8 @@ CMC_API_KEY=000000000000000000000000000000000000000
 PROTOCOL_DEPLOYER_PRIVATE_KEY=0000000000000000000000000000000000000000
 CC_TOKEN_DEPLOYER_PRIVATE_KEY=0000000000000000000000000000000000000000
 
-# Default values for BOSON_TOKEN and DAI_TOKEN are required for local deployment.
+# Default values for BOSON_TOKEN and DAI_TOKEN are required to allow deployment script to work
+# When run locally (env == hardhat), a mock Boson Token is deployed
 # For deployment to a public chain, adjust them accordingly
 BOSON_TOKEN=0x056b1ce5510ceefa6c33600551e55333aff8296f
 DAI_TOKEN=0x6A9865aDE2B6207dAAC49f8bCba9705dEB0B0e6D

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ npm run contracts:compile
 npm run contracts:run
 ```
 
-*Note that*: This command starts up built-in Hardhat Network and migrates all contracts to the Hardhat Network instance. The `.env` file has a hard-coded value for the `BOSON_TOKEN` address, which points to account #9 of the local hardhat network. This isn't an actual BOSON token address but just a valid address that will allow the deployment scripts to work. It's not necessary to deploy a BOSON token to run the unit tests locally (see Unit Tests section), as the unit tests deploy their own contract instances.
+*Note that*: This command starts up built-in Hardhat Network and migrates all contracts to the Hardhat Network instance. The `.env` file has a hard-coded value for the `BOSON_TOKEN` address, which points to account #9 of the local hardhat network. This isn't an actual BOSON token address but just a valid address that will allow the deployment scripts to work. When deploying locally (env == hardhat), a mock Boson Token will be deployed. The unit tests deploy their own contracts and do not rely on the deploy.ts script.
 
 If preferred by those who are familiar with Hardhat, the standard Hardhat commands can be used.
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ npm run contracts:compile
 npm run contracts:run
 ```
 
-*Note that*: This command starts up built-in Hardhat Network and migrates all contracts to the Hardhat Network instance. The `.env` file has a hard-coded value for the `BOSON_TOKEN` address, which points to account #9 of the local hardhat network. This isn't an actual BOSON token address but just a valid address that will allow the deployment scripts to work. When deploying locally (env == hardhat), a mock Boson Token will be deployed. The unit tests deploy their own contracts and do not rely on the deploy.ts script.
+*Note that*: This command starts up built-in Hardhat Network and migrates all contracts to the Hardhat Network instance. The `.env` file has a hard-coded value for the `BOSON_TOKEN` address, which points to account #9 of the local hardhat network. This isn't an actual BOSON token address but just a valid address that will allow the deployment scripts to work. When deploying to a public network, this value should be replaced by the address of the Boson Token on the network you are deploying to. When deploying locally (env == hardhat), a mock Boson Token will be deployed. The unit tests deploy their own contracts and do not rely on the `deploy.ts` script.
 
 If preferred by those who are familiar with Hardhat, the standard Hardhat commands can be used.
 

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -311,6 +311,24 @@ class DeploymentExecutor {
     }
   }
 
+  async deployMockToken() {
+    //only deploy the mock for local environment
+    if(this.env == 'hardhat') {
+      console.log("Deploying mock Boson Token");
+
+      const MockBosonToken = await ethers.getContractFactory('MockERC20Permit');
+      const mockBosonToken = await MockBosonToken.deploy(
+        "Mock Boson Token",
+        "BOSON"
+      );
+
+      await mockBosonToken.deployed();
+      this.boson_token = mockBosonToken.address;
+    } else {
+      console.log("Not local env. NOT deploying mock Boson Token");
+    }
+  }
+
   logContracts() {
     console.log(
       '\nToken Registry Contract Address  %s from deployer address %s: ',
@@ -433,6 +451,7 @@ class NonProdExecutor extends DeploymentExecutor {
     this.SIXTY_SECONDS = 60;
   }
 
+
   async setDefaults() {
     await super.setDefaults();
     await this.voucherKernel.setComplainPeriod(
@@ -459,6 +478,7 @@ class NonProdExecutor extends DeploymentExecutor {
 
 export async function deploy(_env: string): Promise<void> {
   const env = _env.toLowerCase();
+
   if (!isValidEnv(env)) {
     throw new Error(`Env: ${env} is not recognized!`);
   }
@@ -467,6 +487,11 @@ export async function deploy(_env: string): Promise<void> {
     env == 'prod' ? new ProdExecutor() : new NonProdExecutor(env);
 
   await executor.deployContracts();
+
+
+  if(env == 'hardhat') {
+    await executor.deployMockToken();
+  }
 
   executor.logContracts();
   executor.writeContracts();

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -312,9 +312,9 @@ class DeploymentExecutor {
   }
 
   async deployMockToken() {
-    //only deploy the mock for local environment
+    //only deploy the mock for local environment using default deployer address
     if(this.env == 'hardhat') {
-      console.log("Deploying mock Boson Token");
+      console.log("$ Deploying mock Boson Token");
 
       const MockBosonToken = await ethers.getContractFactory('MockERC20Permit');
       const mockBosonToken = await MockBosonToken.deploy(
@@ -419,8 +419,7 @@ class ProdExecutor extends DeploymentExecutor {
 
   async setDefaults() {
     await super.setDefaults();
-    // this code does not seem to be executed. Keeping it in anyways, until it is clear
-    // The lines below are otherwise called also in another setDefaults
+   
     await this.tokenRegistry.setETHLimit(this.eth_limit, this.txOptions);
     console.log(`Set ETH limit: ${this.eth_limit}`);
     await this.tokenRegistry.setTokenLimit(
@@ -443,14 +442,11 @@ class ProdExecutor extends DeploymentExecutor {
  * @extends {DeploymentExecutor}
  */
 class NonProdExecutor extends DeploymentExecutor {
-  SIXTY_SECONDS: number;
 
   constructor(env) {
     super();
     this.env = env;
-    this.SIXTY_SECONDS = 60;
   }
-
 
   async setDefaults() {
     await super.setDefaults();

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -313,19 +313,19 @@ class DeploymentExecutor {
 
   async deployMockToken() {
     //only deploy the mock for local environment using default deployer address
-    if(this.env == 'hardhat') {
-      console.log("$ Deploying mock Boson Token");
+    if (this.env == 'hardhat') {
+      console.log('$ Deploying mock Boson Token');
 
       const MockBosonToken = await ethers.getContractFactory('MockERC20Permit');
       const mockBosonToken = await MockBosonToken.deploy(
-        "Mock Boson Token",
-        "BOSON"
+        'Mock Boson Token',
+        'BOSON'
       );
 
       await mockBosonToken.deployed();
       this.boson_token = mockBosonToken.address;
     } else {
-      console.log("Not local env. NOT deploying mock Boson Token");
+      console.log('Not local env. NOT deploying mock Boson Token');
     }
   }
 
@@ -419,7 +419,7 @@ class ProdExecutor extends DeploymentExecutor {
 
   async setDefaults() {
     await super.setDefaults();
-   
+
     await this.tokenRegistry.setETHLimit(this.eth_limit, this.txOptions);
     console.log(`Set ETH limit: ${this.eth_limit}`);
     await this.tokenRegistry.setTokenLimit(
@@ -442,7 +442,6 @@ class ProdExecutor extends DeploymentExecutor {
  * @extends {DeploymentExecutor}
  */
 class NonProdExecutor extends DeploymentExecutor {
-
   constructor(env) {
     super();
     this.env = env;
@@ -484,8 +483,7 @@ export async function deploy(_env: string): Promise<void> {
 
   await executor.deployContracts();
 
-
-  if(env == 'hardhat') {
+  if (env == 'hardhat') {
     await executor.deployMockToken();
   }
 

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -313,7 +313,7 @@ class DeploymentExecutor {
 
   async deployMockToken() {
     //only deploy the mock for local environment using default deployer address
-    if (this.env == 'hardhat') {
+    if (hre.network.name == 'hardhat' || hre.network.name == 'localhost') {
       console.log('$ Deploying mock Boson Token');
 
       const MockBosonToken = await ethers.getContractFactory('MockERC20Permit');
@@ -325,7 +325,7 @@ class DeploymentExecutor {
       await mockBosonToken.deployed();
       this.boson_token = mockBosonToken.address;
     } else {
-      console.log('Not local env. NOT deploying mock Boson Token');
+      console.log('$ Not local deployment. NOT deploying mock Boson Token');
     }
   }
 
@@ -482,10 +482,7 @@ export async function deploy(_env: string): Promise<void> {
     env == 'prod' ? new ProdExecutor() : new NonProdExecutor(env);
 
   await executor.deployContracts();
-
-  if (env == 'hardhat') {
-    await executor.deployMockToken();
-  }
+  await executor.deployMockToken(); //only deploys mock locally
 
   executor.logContracts();
   executor.writeContracts();


### PR DESCRIPTION
This PR changes the deployment script so that a mock Boson Token is deployed when running locally. The README was also changed to reflect this. In addition, the SIXTY_SECONDS constant was removed because it is no longer used.