### PR TITLE
Adapt the protocol to support meta-transactions

### DIFF
--- a/contracts/ChildDAITokenWrapper.sol
+++ b/contracts/ChildDAITokenWrapper.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+pragma solidity 0.7.6;
+
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "./interfaces/ITokenWrapper.sol";
+import "./interfaces/IChildDAI.sol";
+
+/**
+ * @title ChildDAITokenWrapper
+ * @notice Contract for wrapping call to DAI token permit function because the DAI token permit function has a different signature from other tokens with which the protocol integrates
+ */
+contract ChildDAITokenWrapper is ITokenWrapper, Ownable, ReentrancyGuard {
+
+    address private daiTokenAddress;
+
+
+    constructor(
+        address _daiTokenAddress
+    ) 
+    notZeroAddress(_daiTokenAddress)
+    {
+        daiTokenAddress = _daiTokenAddress;
+        emit LogTokenAddressChanged(_daiTokenAddress, owner());
+    }
+
+    /**
+     * @notice  Checking if a non-zero address is provided, otherwise reverts.
+     */
+    modifier notZeroAddress(address _tokenAddress) {
+        require(_tokenAddress != address(0), "0A"); //zero address
+        _;
+    }
+
+    /**
+     * @notice Conforms to EIP-2612. Calls permit on token, which may or may not have a permit function that conforms to EIP-2612
+     * @param _tokenOwner Address of the token owner who is approving tokens to be transferred by spender
+     * @param _spender Address of the party who is transferring tokens on owner's behalf
+     * @param _deadline Time after which this permission to transfer is no longer valid
+     * @param _v Part of the owner's signatue
+     * @param _r Part of the owner's signatue
+     * @param _s Part of the owner's signatue
+     */
+    function permit(
+        address _tokenOwner,
+        address _spender,
+        uint256,
+        uint256 _deadline,
+        uint8 _v,
+        bytes32 _r,
+        bytes32 _s
+    ) 
+        external
+        override
+        nonReentrant
+        notZeroAddress(_tokenOwner)
+        notZeroAddress(_spender)
+    {
+        // Ensure signature is unique
+        // See https://github.com/OpenZeppelin/openzeppelin-contracts/blob/04695aecbd4d17dddfd55de766d10e3805d6f42f/contracts/cryptography/ECDSA.sol#L5
+        require(uint256(_s) <= 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0, "INVALID_SIG_S");
+        require(_v == 27 || _v == 28, "INVALID_SIG_V");
+        uint nonce =  IChildDAI(daiTokenAddress).getNonce(_tokenOwner);
+        IChildDAI(daiTokenAddress).permit(_tokenOwner, _spender, nonce, _deadline, true, _v, _r, _s);
+        emit LogPermitCalledOnToken(daiTokenAddress, _tokenOwner, _spender, type(uint256).max);
+    }
+
+    /**
+     * @notice Set the address of the wrapper contract for the token. The wrapper is used to, for instance, allow the Boson Protocol functions that use permit functionality to work in a uniform way.
+     * @param _tokenAddress Address of the token which will be updated.
+     */
+    function setTokenAddress(address _tokenAddress)
+        external
+        override
+        onlyOwner
+        notZeroAddress(_tokenAddress)
+    {
+        daiTokenAddress = _tokenAddress;
+        emit LogTokenAddressChanged(_tokenAddress, owner());
+    }
+
+    /**
+     * @notice Get the address of the token wrapped by this contract
+     * @return Address of the token wrapper contract
+     */
+    function getTokenAddress()
+        external
+        view
+        override
+        returns (address)
+    {
+        return daiTokenAddress;
+    }
+}

--- a/contracts/EIP712Base.sol
+++ b/contracts/EIP712Base.sol
@@ -1,0 +1,64 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity ^0.7.0;
+
+contract EIP712Base {
+    struct EIP712Domain {
+        string name;
+        string version;
+        address verifyingContract;
+        bytes32 salt;
+    }
+
+    string constant public ERC712_VERSION = "1";
+
+    bytes32 internal constant EIP712_DOMAIN_TYPEHASH = keccak256(
+        bytes("EIP712Domain(string name,string version,address verifyingContract,bytes32 salt)")
+    );
+    bytes32 internal domainSeperator;
+
+    constructor(string memory name) public {
+        _setDomainSeperator(name);
+    }
+
+    function _setDomainSeperator(string memory name) internal {
+        domainSeperator = keccak256(
+            abi.encode(
+                EIP712_DOMAIN_TYPEHASH,
+                keccak256(bytes(name)),
+                keccak256(bytes(ERC712_VERSION)),
+                address(this),
+                getChainId()
+            )
+        );
+    }
+
+    function getDomainSeperator() public view returns (bytes32) {
+        return domainSeperator;
+    }
+
+    function getChainId() public pure returns (uint256) {
+        uint256 id;
+        assembly {
+            id := chainid()
+        }
+        return id;
+    }
+
+    /**
+     * Accept message hash and returns hash message in EIP712 compatible form
+     * So that it can be used to recover signer from signature signed using EIP712 formatted data
+     * https://eips.ethereum.org/EIPS/eip-712
+     * "\\x19" makes the encoding deterministic
+     * "\\x01" is the version byte to make it compatible to EIP-191
+     */
+    function toTypedMessageHash(bytes32 messageHash)
+        internal
+        view
+        returns (bytes32)
+    {
+        return
+            keccak256(
+                abi.encodePacked("\x19\x01", getDomainSeperator(), messageHash)
+            );
+    }
+}

--- a/contracts/MetaTransactionEIP712Receiver.sol
+++ b/contracts/MetaTransactionEIP712Receiver.sol
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+pragma solidity 0.7.6;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/cryptography/ECDSA.sol";
+import "./EIP712Base.sol";
+
+/*
+ * This contract accepts metatransactions signed by the Owner.
+ * The signature of the Owner is verfied on chain and as a result 
+ * the metatransactions can be sent to the network by any EOA
+ */
+contract MetaTransactionEIP712Receiver is Ownable, EIP712Base {
+
+    using ECDSA for bytes32;
+
+    struct MetaTransaction {
+      uint256 nonce;
+      address from;
+      bytes functionSignature;
+    }
+
+    bytes32 private constant META_TRANSACTION_TYPEHASH = keccak256(
+      bytes(
+          "MetaTransaction(uint256 nonce,address from,bytes functionSignature)"
+      )
+    );
+
+    mapping(uint256 => bool) private usedNonce;
+
+    event ExecutedMetaTransaction(bytes _data, bytes _returnData);
+    event UsedNonce(uint256 _nonce);
+
+    /// @dev Checks if the caller of the method is the contract itself
+    modifier onlyOwnerOrSelf() {
+        require(_msgSender() == owner(), "UNAUTHORIZED_O_SELF");
+        _;
+    }
+
+    constructor(string memory name) EIP712Base(name) {
+    }
+
+    function executeMetaTransaction(
+        uint256 _nonce,
+        address _signer,
+        bytes calldata _data,
+        bytes calldata _signature
+    ) external {
+        // Expecting prefixed data ("boson:") indicating relayed transaction...
+        // ...and an Ethereum Signed Message to protect user from signing an actual Tx
+        require(!usedNonce[_nonce], "METATX_NONCE");
+
+        uint256 id;
+        assembly {
+            id := chainid() //1 for Ethereum mainnet, > 1 for public testnets.
+        }
+        MetaTransaction memory metaTx = MetaTransaction({
+            nonce: _nonce,
+            from: _signer,
+            functionSignature: _data
+        });
+        require(
+            verifySigner(_signer, metaTx, _signature),
+            "Signer and signature do not match"
+        );
+
+        // Store the nonce provided to avoid playback of the same tx
+        usedNonce[_nonce] = true;
+
+        emit UsedNonce(_nonce);
+
+        // invoke local function with an external call
+        // appending _signer at the end to extract it from calling context
+        (bool success, bytes memory returnData) = address(this).call(abi.encodePacked(_data, _signer));
+        require(success, string(returnData));
+
+        emit ExecutedMetaTransaction(_data, returnData);
+    }
+
+   function verifySigner(
+        address signer,
+        MetaTransaction memory metaTx,
+        bytes memory _signature
+    ) internal view returns (bool) {
+        require(signer != address(0), "NativeMetaTransaction: INVALID_SIGNER");
+        bytes32 hash = toTypedMessageHash(hashMetaTransaction(metaTx));
+        address recover = hash.recover(_signature);
+        return (signer == recover);
+    }
+    function hashMetaTransaction(MetaTransaction memory metaTx)
+        internal
+        pure
+        returns (bytes32)
+    {
+        return
+            keccak256(
+                abi.encode(
+                    META_TRANSACTION_TYPEHASH,
+                    metaTx.nonce,
+                    metaTx.from,
+                    keccak256(metaTx.functionSignature)
+                )
+            );
+    }
+
+
+    /// @dev Tells if nonce was used already
+    /// @param _nonce only used for relayed transactions. This is used as an idempotency key
+    /// @return true if used already, otherwise false
+    function isUsedNonce(uint256 _nonce) external view returns(bool) {
+        return usedNonce[_nonce];
+    }
+
+    /// @dev This method ensures that the signature belongs to the owner
+    /// @param _hashedData Hashed data signed on the behalf of address(this)
+    /// @param _signature Signature byte array associated with _dataHash
+    function isValidOwnerSignature(bytes32 _hashedData, bytes memory _signature) public view {
+        address from = _hashedData.recover(_signature);
+        require(owner() == from, "METATX_UNAUTHORIZED");
+    }
+
+    function _msgSender() internal view virtual override returns (address payable) {
+        if(msg.sender == address(this)) {
+            bytes memory array = msg.data;
+            uint256 index = msg.data.length;
+            address payable sender;
+            assembly {
+                // Load the 32 bytes word from memory with the address on the lower 20 bytes, and mask those.
+                sender := and(mload(add(array, index)), 0xffffffffffffffffffffffffffffffffffffffff)
+            }
+            return sender;
+        } else {
+            return msg.sender;
+        }
+    }
+
+}

--- a/contracts/NoPermitTokenWrapper.sol
+++ b/contracts/NoPermitTokenWrapper.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+pragma solidity 0.7.6;
+
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "./interfaces/ITokenWrapper.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "hardhat/console.sol";
+
+/**
+ * @title NoPermitTokenWrapper
+ * @notice Contract for wrapping call any ERC20 token that does not have a permit function
+ */
+contract NoPermitTokenWrapper is ITokenWrapper, Ownable, ReentrancyGuard {
+
+    address private tokenAddress;
+
+
+    constructor(
+        address _tokenAddress
+    ) 
+    notZeroAddress(_tokenAddress)
+    {
+        tokenAddress = _tokenAddress;
+        emit LogTokenAddressChanged(_tokenAddress, owner());
+    }
+
+    /**
+     * @notice  Checking if a non-zero address is provided, otherwise reverts.
+     */
+    modifier notZeroAddress(address _tokenAddress) {
+        require(_tokenAddress != address(0), "0A"); //zero address
+        _;
+    }
+
+    /**
+     * @notice Conforms to EIP-2612. Calls permit on token, which may or may not have a permit function that conforms to EIP-2612
+     * @param _tokenOwner Address of the token owner who is approving tokens to be transferred by spender
+     * @param _spender Address of the party who is transferring tokens on owner's behalf
+     * @param _deadline Time after which this permission to transfer is no longer valid
+     * @param _v Part of the owner's signatue
+     * @param _r Part of the owner's signatue
+     * @param _s Part of the owner's signatue
+     */
+    function permit(
+        address _tokenOwner,
+        address _spender,
+        uint256 _value,
+        uint256 _deadline,
+        uint8 _v,
+        bytes32 _r,
+        bytes32 _s
+    ) 
+        external
+        override
+        nonReentrant
+        notZeroAddress(_tokenOwner)
+        notZeroAddress(_spender)
+    {
+        console.log("calling NoPermitTokenWrapper.permit");
+        uint256 allowance = IERC20(tokenAddress).allowance(_tokenOwner, _spender);
+        console.log("allowance", allowance);
+        console.log("_value", _value);
+        require(allowance >= _value, "ALLOWANCE_TOO_LOW");
+        emit LogPermitCalledOnToken(tokenAddress, _tokenOwner, _spender, _value);
+    }
+
+    /**
+     * @notice Set the address of the wrapper contract for the token. The wrapper is used to, for instance, allow the Boson Protocol functions that use permit functionality to work in a uniform way.
+     * @param _tokenAddress Address of the token which will be updated.
+     */
+    function setTokenAddress(address _tokenAddress)
+        external
+        override
+        onlyOwner
+        notZeroAddress(_tokenAddress)
+    {
+        tokenAddress = _tokenAddress;
+        emit LogTokenAddressChanged(_tokenAddress, owner());
+    }
+
+    /**
+     * @notice Get the address of the token wrapped by this contract
+     * @return Address of the token wrapper contract
+     */
+    function getTokenAddress()
+        external
+        view
+        override
+        returns (address)
+    {
+        return tokenAddress;
+    }
+}

--- a/contracts/interfaces/IBosonRouter.sol
+++ b/contracts/interfaces/IBosonRouter.sol
@@ -44,6 +44,13 @@ interface IBosonRouter {
         uint256[] calldata _metadata
     ) external;
 
+    function requestCreateOrderTKNTKNNoPermit(
+        address _tokenPriceAddress,
+        address _tokenDepositAddress,
+        uint256 _tokensSent,
+        uint256[] calldata _metadata
+    ) external;
+
     function requestCreateOrderTKNTKNWithPermitConditional(
         address _tokenPriceAddress,
         address _tokenDepositAddress,
@@ -52,6 +59,15 @@ interface IBosonRouter {
         uint8 _v,
         bytes32 _r,
         bytes32 _s,
+        uint256[] calldata _metadata,
+        address _gateAddress,
+        uint256 _nftTokenId
+    ) external;
+
+    function requestCreateOrderTKNTKNNoPermitConditional(
+        address _tokenPriceAddress,
+        address _tokenDepositAddress,
+        uint256 _tokensSent,
         uint256[] calldata _metadata,
         address _gateAddress,
         uint256 _nftTokenId
@@ -121,6 +137,12 @@ interface IBosonRouter {
         uint8 _v,
         bytes32 _r,
         bytes32 _s
+    ) external;
+
+    function requestVoucherTKNTKNNoPermit(
+        uint256 _tokenIdSupply,
+        address _issuer,
+        uint256 _tokensSent
     ) external;
 
     function requestVoucherETHTKNWithPermit(

--- a/contracts/interfaces/IChildDAI.sol
+++ b/contracts/interfaces/IChildDAI.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+pragma solidity 0.7.6;
+
+/**
+ * @title IChildDAI
+ * @notice Interface for the purpose of calling the permit function on the deployed Child DAI token
+ */
+interface IChildDAI {
+    function name() external pure returns (string memory);
+
+    function permit(
+        address _holder,
+        address _spender,
+        uint256 _nonce,
+        uint256 _expiry,
+        bool _allowed,
+        uint8 _v,
+        bytes32 _r,
+        bytes32 _s
+    ) external;
+
+    function transferFrom(
+        address _from,
+        address _to,
+        uint256 _value
+    ) external returns (bool);
+
+    function getNonce(address _owner) external view returns (uint256);
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -48,9 +48,14 @@ const config: HardhatUserConfig = {
 	},
 	defaultNetwork: "hardhat",
 	networks: {
+		localhost: {
+      url: 'http://localhost:8545',
+      accounts: {mnemonic: testMnemonic, count: 10},
+      chainId: 31337,
+    },
 		hardhat: {
 			accounts: {mnemonic: testMnemonic, count: 10},
-			chainId: 1
+			chainId: 31337
 		},
 		rinkeby: {
 			url: `https://rinkeby.infura.io/v3/${INFURA_KEY}`,
@@ -65,6 +70,12 @@ const config: HardhatUserConfig = {
 			accounts: ACCOUNTS,
 			initialBaseFeePerGas: 0
 		},
+    mumbai: {
+      url: `https://rpc-mumbai.maticvigil.com/v1/${INFURA_KEY}`,
+      chainId: 80001,
+			accounts: ACCOUNTS,
+      gasPrice: 8000000000, // default is 'auto' which breaks chains without the london hardfork
+    },
 	},
 	etherscan: {
 		apiKey: process.env.ETHERSCAN_API_KEY


### PR DESCRIPTION
No expectation to be merged as is.
Just a draft to show and demonstrate how to adapt the protocol contracts to support meta-transactions, with the protocol contracts deployed on a layer2 chain.
Limited to the methods of the BosonRouter contract (assuming that if a user needs to call methods of other contracts, it's still possible to switch the wallet to the layer2 to call them directly)
Support of tokens without Permit method have been added too. Methods requestCreateOrderTKNTKNNoPermit, requestCreateOrderTKNTKNNoPermitConditional, and requestVoucherTKNTKNNoPermit have been created to clarify the calls (even if, basically, it would be enough to call existing methods with null values for deadline and the signature fields).
Support of the tokens without Permit is possible thanks to a specific token Wrapper contract (NoPermitTokenWrapper), assuming that the approve method has been called beforehand to allow the BosonRouter contract to transfer user"s funds.