### PR TITLE
Modify call to permit to not require token wrapper

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+contracts/mocks/

--- a/.solhintignore
+++ b/.solhintignore
@@ -1,0 +1,1 @@
+contracts/mocks/

--- a/contracts/BosonRouter.sol
+++ b/contracts/BosonRouter.sol
@@ -883,9 +883,12 @@ contract BosonRouter is
     ) internal {
         address tokenWrapper = ITokenRegistry(tokenRegistry)
             .getTokenWrapperAddress(_token);
-      
-        if(tokenWrapper != address(0)) { //tokens like DAI don't conform to EIP-2612, so a token wrapper is needed
-            ITokenWrapper(tokenWrapper).permit(
+
+        bool isWrapped = ( tokenWrapper != address(0) );
+
+        //The IERC20WithPermit and ITokenWrapper permit functions have the same signature, so we can cast either
+        //the retrieved tokenWrapper address or the passed in _token address to make the call
+        IERC20WithPermit(isWrapped ? tokenWrapper : _token ).permit(
                 _tokenOwner,
                 _spender,
                 _value,
@@ -894,17 +897,6 @@ contract BosonRouter is
                 _r,
                 _s
             );
-        } else { //we assume the token has a permit function that conforms to EIP-2612, but it may not.
-            IERC20WithPermit(_token).permit(
-                _tokenOwner,
-                _spender,
-                _value,
-                _deadline,
-                _v,
-                _r,
-                _s
-            );
-        }
       
     }
 

--- a/contracts/BosonRouter.sol
+++ b/contracts/BosonRouter.sol
@@ -883,19 +883,29 @@ contract BosonRouter is
     ) internal {
         address tokenWrapper = ITokenRegistry(tokenRegistry)
             .getTokenWrapperAddress(_token);
-        require(tokenWrapper != address(0), "UNSUPPORTED_TOKEN");
-
-        //The BosonToken contract conforms to this spec, so it will be callable this way
-        //if it's address is mapped to itself in the TokenRegistry
-        ITokenWrapper(tokenWrapper).permit(
-            _tokenOwner,
-            _spender,
-            _value,
-            _deadline,
-            _v,
-            _r,
-            _s
-        );
+      
+        if(tokenWrapper != address(0)) { //tokens like DAI don't conform to EIP-2612, so a token wrapper is needed
+            ITokenWrapper(tokenWrapper).permit(
+                _tokenOwner,
+                _spender,
+                _value,
+                _deadline,
+                _v,
+                _r,
+                _s
+            );
+        } else { //we assume the token has a permit function that conforms to EIP-2612, but it may not.
+            IERC20WithPermit(_token).permit(
+                _tokenOwner,
+                _spender,
+                _value,
+                _deadline,
+                _v,
+                _r,
+                _s
+            );
+        }
+      
     }
 
     /**

--- a/contracts/mocks/MockDai.sol
+++ b/contracts/mocks/MockDai.sol
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Copyright (C) 2017, 2018, 2019 dbrock, rain, mrchico
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity 0.5.12;
+
+// FIXME: This contract was altered compared to the production version.
+// It doesn't use LibNote anymore.
+// New deployments of this contract will need to include custom events (TO DO).
+
+contract MockDai {
+    // --- Auth ---
+    mapping (address => uint) public wards;
+    function rely(address guy) external auth { wards[guy] = 1; }
+    function deny(address guy) external auth { wards[guy] = 0; }
+    modifier auth {
+        require(wards[msg.sender] == 1, "Dai/not-authorized");
+        _;
+    }
+
+    // --- ERC20 Data ---
+    string  public constant name     = "Mock Dai Stablecoin";
+    string  public constant symbol   = "MOCKDAI";
+    string  public constant version  = "1";
+    uint8   public constant decimals = 18;
+    uint256 public totalSupply;
+
+    mapping (address => uint)                      public balanceOf;
+    mapping (address => mapping (address => uint)) public allowance;
+    mapping (address => uint)                      public nonces;
+
+    event Approval(address indexed src, address indexed guy, uint wad);
+    event Transfer(address indexed src, address indexed dst, uint wad);
+
+    // --- Math ---
+    function add(uint x, uint y) internal pure returns (uint z) {
+        require((z = x + y) >= x);
+    }
+    function sub(uint x, uint y) internal pure returns (uint z) {
+        require((z = x - y) <= x);
+    }
+
+    // --- EIP712 niceties ---
+    bytes32 public DOMAIN_SEPARATOR;
+    // bytes32 public constant PERMIT_TYPEHASH = keccak256("Permit(address holder,address spender,uint256 nonce,uint256 expiry,bool allowed)");
+    bytes32 public constant PERMIT_TYPEHASH = 0xea2aa0a1be11a07ed86d755c93467f4f82362b452371d1ba94d1715123511acb;
+
+    constructor(uint256 chainId_) public {
+        wards[msg.sender] = 1;
+        DOMAIN_SEPARATOR = keccak256(abi.encode(
+            keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+            keccak256(bytes(name)),
+            keccak256(bytes(version)),
+            chainId_,
+            address(this)
+        ));
+    }
+
+    // --- Token ---
+    function transfer(address dst, uint wad) external returns (bool) {
+        return transferFrom(msg.sender, dst, wad);
+    }
+    function transferFrom(address src, address dst, uint wad)
+        public returns (bool)
+    {
+        require(balanceOf[src] >= wad, "Dai/insufficient-balance");
+        if (src != msg.sender && allowance[src][msg.sender] != uint(-1)) {
+            require(allowance[src][msg.sender] >= wad, "Dai/insufficient-allowance");
+            allowance[src][msg.sender] = sub(allowance[src][msg.sender], wad);
+        }
+        balanceOf[src] = sub(balanceOf[src], wad);
+        balanceOf[dst] = add(balanceOf[dst], wad);
+        emit Transfer(src, dst, wad);
+        return true;
+    }
+    function mint(address usr, uint wad) external auth {
+        balanceOf[usr] = add(balanceOf[usr], wad);
+        totalSupply    = add(totalSupply, wad);
+        emit Transfer(address(0), usr, wad);
+    }
+    function burn(address usr, uint wad) external {
+        require(balanceOf[usr] >= wad, "Dai/insufficient-balance");
+        if (usr != msg.sender && allowance[usr][msg.sender] != uint(-1)) {
+            require(allowance[usr][msg.sender] >= wad, "Dai/insufficient-allowance");
+            allowance[usr][msg.sender] = sub(allowance[usr][msg.sender], wad);
+        }
+        balanceOf[usr] = sub(balanceOf[usr], wad);
+        totalSupply    = sub(totalSupply, wad);
+        emit Transfer(usr, address(0), wad);
+    }
+    function approve(address usr, uint wad) external returns (bool) {
+        allowance[msg.sender][usr] = wad;
+        emit Approval(msg.sender, usr, wad);
+        return true;
+    }
+
+    // --- Alias ---
+    function push(address usr, uint wad) external {
+        transferFrom(msg.sender, usr, wad);
+    }
+    function pull(address usr, uint wad) external {
+        transferFrom(usr, msg.sender, wad);
+    }
+    function move(address src, address dst, uint wad) external {
+        transferFrom(src, dst, wad);
+    }
+
+    // --- Approve by signature ---
+    function permit(address holder, address spender, uint256 nonce, uint256 expiry,
+                    bool allowed, uint8 v, bytes32 r, bytes32 s) external
+    {
+        bytes32 digest =
+            keccak256(abi.encodePacked(
+                "\x19\x01",
+                DOMAIN_SEPARATOR,
+                keccak256(abi.encode(PERMIT_TYPEHASH,
+                                     holder,
+                                     spender,
+                                     nonce,
+                                     expiry,
+                                     allowed))
+        ));
+
+        require(holder != address(0), "Dai/invalid-address-0");
+        require(holder == ecrecover(digest, v, r, s), "Dai/invalid-permit");
+        require(expiry == 0 || now <= expiry, "Dai/permit-expired");
+        require(nonce == nonces[holder]++, "Dai/invalid-nonce");
+        uint wad = allowed ? uint(-1) : 0;
+        allowance[holder][spender] = wad;
+        emit Approval(holder, spender, wad);
+    }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -38,13 +38,26 @@ task("contracts-verify", "Verify already deployed contracts. Bear in mind that a
 
 const config: HardhatUserConfig = {
 	solidity: {
-		version: "0.7.6",
-		settings: {
-			optimizer: {
-				enabled: true,
-				runs: 200
-			}
-		}
+		compilers: [
+			{
+			  version: "0.5.12",
+			  settings: {
+					optimizer: {
+						enabled: true,
+						runs: 200
+					}
+				}
+			},
+			{
+			  version: "0.7.6",
+			  settings: {
+					optimizer: {
+						enabled: true,
+						runs: 200
+					}
+				}
+			},
+		  ],
 	},
 	defaultNetwork: "hardhat",
 	networks: {

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -145,21 +145,6 @@ class DeploymentExecutor {
       event.args._newWrapperAddress
     );
 
-    tx = await this.tokenRegistry.setTokenWrapperAddress(
-      this.boson_token,
-      this.boson_token,
-      this.txOptions
-    );
-
-    txReceipt = await tx.wait();
-    event = txReceipt.events[0];
-    console.log(
-      '$ TokenRegistry',
-      event.event,
-      'at:',
-      event.args._newWrapperAddress
-    );
-
     tx = await this.br.setGateApproval(this.gate.address, true, this.txOptions);
 
     txReceipt = await tx.wait();

--- a/test/11_gate.ts
+++ b/test/11_gate.ts
@@ -174,17 +174,6 @@ describe('Gate contract', async () => {
       constants.TOKEN_LIMIT
     );
     await contractTokenRegistry.setETHLimit(constants.ETHER_LIMIT);
-
-    //Map $BOSON token to itself so that the token address can be called by casting to the wrapper interface in the Boson Router
-    await contractTokenRegistry.setTokenWrapperAddress(
-      contractBSNTokenPrice.address,
-      contractBSNTokenPrice.address
-    );
-
-    await contractTokenRegistry.setTokenWrapperAddress(
-      contractBSNTokenDeposit.address,
-      contractBSNTokenDeposit.address
-    );
   }
 
   async function registerVoucherSetIdFromBosonProtocol(

--- a/test/12_conditional_commit.ts
+++ b/test/12_conditional_commit.ts
@@ -186,17 +186,6 @@ describe('Create Voucher sets and commit to vouchers with token conditional comm
 
     await contractTokenRegistry.setETHLimit(constants.ETHER_LIMIT);
 
-    //Map $BOSON token to itself so that the token address can be called by casting to the wrapper interface in the Boson Router
-    await contractTokenRegistry.setTokenWrapperAddress(
-      contractBSNTokenPrice.address,
-      contractBSNTokenPrice.address
-    );
-
-    await contractTokenRegistry.setTokenWrapperAddress(
-      contractBSNTokenDeposit.address,
-      contractBSNTokenDeposit.address
-    );
-
     await contractBosonRouter.setGateApproval(contractGate.address, true);
   }
 

--- a/test/14_voucherKernel.ts
+++ b/test/14_voucherKernel.ts
@@ -165,17 +165,6 @@ describe('VOUCHER KERNEL', () => {
       constants.TOKEN_LIMIT
     );
     await contractTokenRegistry.setETHLimit(constants.ETHER_LIMIT);
-
-    //Set Boson Token as it's own wrapper so that the same interface can be called in the code
-    await contractTokenRegistry.setTokenWrapperAddress(
-      contractBSNTokenPrice.address,
-      contractBSNTokenPrice.address
-    );
-
-    await contractTokenRegistry.setTokenWrapperAddress(
-      contractBSNTokenDeposit.address,
-      contractBSNTokenDeposit.address
-    );
   }
 
   describe('With normal deployment', () => {

--- a/test/2_test_fullpath_with_permit.ts
+++ b/test/2_test_fullpath_with_permit.ts
@@ -187,17 +187,6 @@ describe('Cashier and VoucherKernel', () => {
     );
     await contractTokenRegistry.setETHLimit(constants.ETHER_LIMIT);
 
-    //Set Boson Token as it's own wrapper so that the same interface can be called in the code
-    await contractTokenRegistry.setTokenWrapperAddress(
-      contractBSNTokenPrice.address,
-      contractBSNTokenPrice.address
-    );
-
-    await contractTokenRegistry.setTokenWrapperAddress(
-      contractBSNTokenDeposit.address,
-      contractBSNTokenDeposit.address
-    );
-
     // calculate expected tokenSupplyID for first voucher
     promiseId = keccak256(
       solidityPack(

--- a/test/3_withdrawals.ts
+++ b/test/3_withdrawals.ts
@@ -159,17 +159,6 @@ describe('Cashier withdrawals ', () => {
       constants.TOKEN_LIMIT
     );
     await contractTokenRegistry.setETHLimit(constants.ETHER_LIMIT);
-
-    //Set Boson Token as it's own wrapper so that the same interface can be called in the code
-    await contractTokenRegistry.setTokenWrapperAddress(
-      contractBSNTokenPrice.address,
-      contractBSNTokenPrice.address
-    );
-
-    await contractTokenRegistry.setTokenWrapperAddress(
-      contractBSNTokenDeposit.address,
-      contractBSNTokenDeposit.address
-    );
   }
 
   async function setPeriods() {

--- a/test/4_pausing_contracts.ts
+++ b/test/4_pausing_contracts.ts
@@ -156,17 +156,6 @@ describe('Cashier && VK', () => {
     );
     await contractTokenRegistry.setETHLimit(constants.ETHER_LIMIT);
 
-    //Set Boson Token as it's own wrapper so that the same interface can be called in the code
-    await contractTokenRegistry.setTokenWrapperAddress(
-      contractBSNTokenPrice.address,
-      contractBSNTokenPrice.address
-    );
-
-    await contractTokenRegistry.setTokenWrapperAddress(
-      contractBSNTokenDeposit.address,
-      contractBSNTokenDeposit.address
-    );
-
     utils = await UtilsBuilder.create()
       .ETHETH()
       .buildAsync(

--- a/test/6_a_voucher_sets.ts
+++ b/test/6_a_voucher_sets.ts
@@ -176,17 +176,6 @@ describe('Voucher Sets', () => {
       constants.TOKEN_LIMIT
     );
     await contractTokenRegistry.setETHLimit(constants.ETHER_LIMIT);
-
-    //Set Boson Token as it's own wrapper so that the same interface can be called in the code
-    await contractTokenRegistry.setTokenWrapperAddress(
-      contractBSNTokenPrice.address,
-      contractBSNTokenPrice.address
-    );
-
-    await contractTokenRegistry.setTokenWrapperAddress(
-      contractBSNTokenDeposit.address,
-      contractBSNTokenDeposit.address
-    );
   }
 
   async function prepareUtils() {

--- a/test/6_b_voucher.ts
+++ b/test/6_b_voucher.ts
@@ -174,17 +174,6 @@ describe('Vouchers', () => {
       constants.TOKEN_LIMIT
     );
     await contractTokenRegistry.setETHLimit(constants.ETHER_LIMIT);
-
-    //Set Boson Token as it's own wrapper so that the same interface can be called in the code
-    await contractTokenRegistry.setTokenWrapperAddress(
-      contractBSNTokenPrice.address,
-      contractBSNTokenPrice.address
-    );
-
-    await contractTokenRegistry.setTokenWrapperAddress(
-      contractBSNTokenDeposit.address,
-      contractBSNTokenDeposit.address
-    );
   }
 
   async function prepareUtils() {

--- a/testHelpers/revertReasons.ts
+++ b/testHelpers/revertReasons.ts
@@ -100,4 +100,6 @@ export default {
   NOTHING_TO_WITHDRAW: 'NOTHING_TO_WITHDRAW',
   VALID_FROM_MUST_BE_AT_LEAST_5_MINUTES_LESS_THAN_VALID_TO:
     'VALID_FROM_MUST_BE_AT_LEAST_5_MINUTES_LESS_THAN_VALID_TO',
+  FUNCTION_NOT_RECOGNIZED_NO_FALLBACK:
+    "function selector was not recognized and there's no fallback function",
 };


### PR DESCRIPTION
This enables tokens to be supported without first having to be registered with a wrapper if they conform to EIP-2612. Any token that has a permit function that does NOT conform to EIP-2612 (such as DAI) must have a registered wrapper