### PR TITLE
Refactor withdraw Code coverage fix

### DIFF
--- a/.github/workflows/code-coverage-check.yaml
+++ b/.github/workflows/code-coverage-check.yaml
@@ -9,6 +9,7 @@ jobs:
     env:
       PROTOCOL_DEPLOYER_PRIVATE_KEY: 123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234
       CC_TOKEN_DEPLOYER_PRIVATE_KEY: 123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234
+      NODE_OPTIONS: --max_old_space_size=8192
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -21,8 +22,6 @@ jobs:
         run: npm install
       - name: Compile Contracts
         run: npm run contracts:compile
-      - name: Set NODE_OPTIONS
-        run: export NODE_OPTIONS=--max_old_space_size=8192
       - name: Get NODE_OPTIONS
         run: echo $NODE_OPTIONS
       - name: Code Coverage

--- a/.github/workflows/code-coverage-check.yaml
+++ b/.github/workflows/code-coverage-check.yaml
@@ -2,7 +2,7 @@ name: Code Coverage Check
 
 on:
   push:
-    branches: [ refactor-withdraw_code_coverage_check ]
+    branches: [ main ]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/code-coverage-check.yaml
+++ b/.github/workflows/code-coverage-check.yaml
@@ -9,7 +9,7 @@ jobs:
     env:
       PROTOCOL_DEPLOYER_PRIVATE_KEY: 123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234
       CC_TOKEN_DEPLOYER_PRIVATE_KEY: 123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234
-      NODE_OPTIONS: --max_old_space_size=8192
+      NODE_OPTIONS: --max_old_space_size=4096
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -22,8 +22,6 @@ jobs:
         run: npm install
       - name: Compile Contracts
         run: npm run contracts:compile
-      - name: Get NODE_OPTIONS
-        run: echo $NODE_OPTIONS
       - name: Code Coverage
         run: npm run tests:coverage
       - name: Check Code Coverage

--- a/.github/workflows/code-coverage-check.yaml
+++ b/.github/workflows/code-coverage-check.yaml
@@ -2,7 +2,7 @@ name: Code Coverage Check
 
 on:
   push:
-    branches: [ main ]
+    branches: [ refactor-withdraw_code_coverage_check ]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/code-coverage-check.yaml
+++ b/.github/workflows/code-coverage-check.yaml
@@ -22,7 +22,9 @@ jobs:
       - name: Compile Contracts
         run: npm run contracts:compile
       - name: Set NODE_OPTIONS
-        run: export NODE_OPTIONS=--max_old_space_size=4096
+        run: export NODE_OPTIONS=--max_old_space_size=8192
+      - name: Get NODE_OPTIONS
+        run: echo $NODE_OPTIONS
       - name: Code Coverage
         run: npm run tests:coverage
       - name: Check Code Coverage

--- a/.github/workflows/code-coverage-check.yaml
+++ b/.github/workflows/code-coverage-check.yaml
@@ -21,6 +21,8 @@ jobs:
         run: npm install
       - name: Compile Contracts
         run: npm run contracts:compile
+      - name: Set NODE_OPTIONS
+        run: export NODE_OPTIONS=--max_old_space_size=4096
       - name: Code Coverage
         run: npm run tests:coverage
       - name: Check Code Coverage


### PR DESCRIPTION
This PR fixes the error `FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory` in Github Actions.

Please note that Code coverage runs when the PRs get merged into `main`.

Depends on https://github.com/bosonprotocol/contracts/pull/309