### PR TITLE
Track seller per voucher, not pet voucher set

### DIFF
--- a/contracts/Cashier.sol
+++ b/contracts/Cashier.sol
@@ -248,8 +248,8 @@ contract Cashier is ICashier, ReentrancyGuard, Ownable, Pausable {
         );
 
         voucherDetails.issuer = payable(
-            IVoucherKernel(voucherKernel).getSupplyHolder(
-                voucherDetails.tokenIdSupply
+            IVoucherKernel(voucherKernel).getVoucherSeller(
+                _tokenIdVoucher
             )
         );
         voucherDetails.holder = payable(

--- a/contracts/UsingHelpers.sol
+++ b/contracts/UsingHelpers.sol
@@ -35,6 +35,7 @@ struct VoucherDetails {
 }
 
 struct VoucherStatus {
+    address seller;
     uint8 status;
     bool isPaymentReleased;
     bool isDepositsReleased;

--- a/contracts/VoucherKernel.sol
+++ b/contracts/VoucherKernel.sol
@@ -463,6 +463,7 @@ contract VoucherKernel is IVoucherKernel, Ownable, Pausable, ReentrancyGuard {
         );
         vouchersStatus[voucherTokenId].isPaymentReleased = false;
         vouchersStatus[voucherTokenId].isDepositsReleased = false;
+        vouchersStatus[voucherTokenId].seller = getSupplyHolder(_tokenIdSupply);
 
         //mint voucher NFT as ERC-721
         IVouchers(voucherTokenAddress).mint(_to, voucherTokenId);
@@ -1082,6 +1083,16 @@ contract VoucherKernel is IVoucherKernel, Ownable, Pausable, ReentrancyGuard {
     {
         bytes32 promiseKey = ordersPromise[_tokenIdSupply];
         return promises[promiseKey].seller;
+    }
+
+
+    /**
+     * @notice Get the issuer of a voucher
+     * @param _voucherTokenId ID of the voucher token
+     * @return                Address of the seller, when voucher was created
+     */
+    function getVoucherSeller(uint256 _voucherTokenId) external view override returns (address) {
+        return vouchersStatus[_voucherTokenId].seller;
     }
 
     /**

--- a/contracts/VoucherKernel.sol
+++ b/contracts/VoucherKernel.sol
@@ -568,9 +568,8 @@ contract VoucherKernel is IVoucherKernel, Ownable, Pausable, ReentrancyGuard {
         onlyFromRouter
         whenNotPaused
     {
-        uint256 tokenIdSupply = getIdSupplyFromVoucher(_tokenIdVoucher);
         require(
-            getSupplyHolder(tokenIdSupply) == _messageSender,
+            vouchersStatus[_tokenIdVoucher].seller ==_messageSender,
             "UNAUTHORIZED_COF"
         );
 

--- a/contracts/interfaces/IVoucherKernel.sol
+++ b/contracts/interfaces/IVoucherKernel.sol
@@ -317,6 +317,16 @@ interface IVoucherKernel {
         returns (address);
 
     /**
+     * @notice Get the issuer of a voucher
+     * @param _voucherTokenId ID of the voucher token
+     * @return                Address of the seller, when voucher was created
+     */
+    function getVoucherSeller(uint256 _voucherTokenId)
+        external
+        view
+        returns (address);
+
+    /**
      * @notice Get the holder of a voucher
      * @param _tokenIdVoucher   ID of the voucher token
      * @return                  Address of the holder

--- a/test/2_test_fullpath_with_permit.ts
+++ b/test/2_test_fullpath_with_permit.ts
@@ -4059,7 +4059,7 @@ describe('Cashier and VoucherKernel', () => {
         ).to.be.revertedWith(revertReasons.INEXISTENT_SUPPLY);
       });
 
-      it.only('[!CANCEL] It should not be possible to cancel voucher that does not exist yet', async () => {
+      it('[!CANCEL] It should not be possible to cancel voucher that does not exist yet', async () => {
         // spoof boson router address
         await contractBosonRouter.pause();
         await contractVoucherKernel.setBosonRouterAddress(

--- a/test/2_test_fullpath_with_permit.ts
+++ b/test/2_test_fullpath_with_permit.ts
@@ -5412,7 +5412,7 @@ describe('Cashier and VoucherKernel', () => {
           ).to.equal('0');
         });
 
-        it('After transfer, old seller cannot manage new vouchers anymore', async () => {
+        it('After transfer, old seller cannot manage new vouchers', async () => {
           const bosonRouterOldSeller = contractBosonRouter.connect(
             users.other1.signer
           );

--- a/test/2_test_fullpath_with_permit.ts
+++ b/test/2_test_fullpath_with_permit.ts
@@ -5412,7 +5412,7 @@ describe('Cashier and VoucherKernel', () => {
           ).to.equal('0');
         });
 
-        it.only('After transfer, old seller cannot manage new vouchers anymore', async () => {
+        it('After transfer, old seller cannot manage new vouchers anymore', async () => {
           const bosonRouterOldSeller = contractBosonRouter.connect(
             users.other1.signer
           );

--- a/test/2_test_fullpath_with_permit.ts
+++ b/test/2_test_fullpath_with_permit.ts
@@ -4059,7 +4059,7 @@ describe('Cashier and VoucherKernel', () => {
         ).to.be.revertedWith(revertReasons.INEXISTENT_SUPPLY);
       });
 
-      it('[!CANCEL] It should not be possible to cancel voucher that does not exist yet', async () => {
+      it.only('[!CANCEL] It should not be possible to cancel voucher that does not exist yet', async () => {
         // spoof boson router address
         await contractBosonRouter.pause();
         await contractVoucherKernel.setBosonRouterAddress(
@@ -4070,7 +4070,7 @@ describe('Cashier and VoucherKernel', () => {
         await expect(
           contractVoucherKernel.cancelOrFault(
             BN(TOKEN_SUPPLY_ID).or(1),
-            users.seller.address
+            constants.ZERO_ADDRESS
           )
         ).to.be.revertedWith(revertReasons.INAPPLICABLE_STATUS);
       });


### PR DESCRIPTION
This PR resolves the issue of mismatch between voucher seller and escrow, which happened if voucherSet was transfered to the new owner, while some of vouchers were not finalised yet.

Changes:
- added `address seller` to voucherStatus, which is populated when buyer commits to the offer
- added function `getVoucherSeller` which is used instead of `getSupplyHolder` in voucher interactions