### PR TITLE
Deploy mock tokens

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -29,6 +29,14 @@ task("deploy", "Deploy contracts on a provided network")
 		await deploy(env);
 	})
 
+task("deploy-mocks", "Deploy mock conditional token contracts (ERC20, ERC721, ERC1155) on a provided network")
+	.addOptionalParam("env", "(Optional) Provide additional context on which environment the contracts are deployed to: production, staging or testing", "")
+	.setAction( async ({env}) => {
+		const { deploy } = await lazyImport('./scripts/deploy-mocks')
+		await deploy(env);
+	})
+
+
 task("contracts-verify", "Verify already deployed contracts. Bear in mind that at least couple of blocks should be mined before execution!")
 	.addOptionalParam("env", "(Optional) Provide additional context on which environment the contracts are deployed to: production, staging or testing", "")
 	.setAction(async ({env}) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7908,7 +7908,9 @@
                 "chownr": {
                     "version": "1.1.4",
                     "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-                    "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+                    "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+                    "dev": true,
+                    "optional": true
                 },
                 "ci-info": {
                     "version": "2.0.0",
@@ -11901,6 +11903,8 @@
                     "version": "1.3.3",
                     "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
                     "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+                    "dev": true,
+                    "optional": true,
                     "requires": {
                         "minipass": "^2.9.0"
                     },
@@ -11909,6 +11913,7 @@
                             "version": "2.9.0",
                             "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
                             "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+                            "dev": true,
                             "optional": true,
                             "requires": {
                                 "safe-buffer": "^5.1.2",
@@ -12067,6 +12072,13 @@
                     "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
                     "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
                     "dev": true
+                },
+                "normalize-url": {
+                    "version": "4.5.0",
+                    "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+                    "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+                    "dev": true,
+                    "optional": true
                 },
                 "number-to-bn": {
                     "version": "1.7.0",
@@ -12427,6 +12439,12 @@
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
                     "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+                    "dev": true
+                },
+                "path-parse": {
+                    "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+                    "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
                     "dev": true
                 },
                 "path-to-regexp": {
@@ -12917,7 +12935,8 @@
                 "safe-buffer": {
                     "version": "5.2.1",
                     "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+                    "dev": true
                 },
                 "safe-event-emitter": {
                     "version": "1.0.1",
@@ -13120,7 +13139,21 @@
                 "simple-concat": {
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-                    "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+                    "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+                    "dev": true,
+                    "optional": true
+                },
+                "simple-get": {
+                    "version": "2.8.1",
+                    "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
+                    "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "decompress-response": "^3.3.0",
+                        "once": "^1.3.1",
+                        "simple-concat": "^1.0.0"
+                    }
                 },
                 "snapdragon": {
                     "version": "0.8.2",
@@ -13703,6 +13736,45 @@
                             "dev": true,
                             "requires": {
                                 "path-parse": "^1.0.6"
+                            }
+                        }
+                    }
+                },
+                "tar": {
+                    "version": "4.4.13",
+                    "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+                    "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "chownr": "^1.1.1",
+                        "fs-minipass": "^1.2.5",
+                        "minipass": "^2.8.6",
+                        "minizlib": "^1.2.1",
+                        "mkdirp": "^0.5.0",
+                        "safe-buffer": "^5.1.2",
+                        "yallist": "^3.0.3"
+                    },
+                    "dependencies": {
+                        "fs-minipass": {
+                            "version": "1.2.7",
+                            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+                            "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "minipass": "^2.6.0"
+                            }
+                        },
+                        "minipass": {
+                            "version": "2.9.0",
+                            "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+                            "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "safe-buffer": "^5.1.2",
+                                "yallist": "^3.0.0"
                             }
                         }
                     }
@@ -14983,7 +15055,8 @@
                 "yallist": {
                     "version": "3.1.1",
                     "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-                    "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+                    "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+                    "dev": true
                 }
             }
         },
@@ -16665,6 +16738,12 @@
                 "graceful-fs": "^4.1.11"
             }
         },
+        "kleur": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+            "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+            "dev": true
+        },
         "lcid": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
@@ -18093,6 +18172,16 @@
                 "asap": "~2.0.6"
             }
         },
+        "prompts": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+            "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+            "dev": true,
+            "requires": {
+                "kleur": "^3.0.3",
+                "sisteransi": "^1.0.5"
+            }
+        },
         "proxy-addr": {
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -18833,6 +18922,12 @@
                 "once": "^1.3.1",
                 "simple-concat": "^1.0.0"
             }
+        },
+        "sisteransi": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+            "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+            "dev": true
         },
         "slash": {
             "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -105,13 +105,11 @@
         "node-fetch": "^3.1.1",
         "prettier": "^2.2.1",
         "prettier-plugin-solidity": "^1.0.0-beta.3",
+        "prompts": "^2.4.2",
         "solhint": "^3.3.2",
         "solidity-coverage": "^0.7.12",
         "ts-node": "^10.0.0",
         "typechain": "^5.0.0",
         "typescript": "^4.3.2"
-    },
-    "dependencies": {
-        "prompts": "^2.4.2"
     }
 }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
         "contracts:migrate:staging:rinkeby": "npm run contracts:clean && npm run contracts:compile && hardhat deploy --network rinkeby --env staging",
         "contracts:migrate:staging": "npm run contracts:clean && npm run contracts:compile && hardhat deploy --network ropsten --env staging",
         "contracts:migrate:production": "npm run contracts:clean && npm run contracts:compile && hardhat deploy --network mainnet --env production",
+        "contracts:migrate:mocks": "npm run contracts:clean && npm run contracts:compile && hardhat deploy-mocks --network ropsten --env testing",
+        "contracts:migrate:mocks:rinkeby": "npm run contracts:clean && npm run contracts:compile && hardhat deploy-mocks --network rinkeby --env testing",
         "contracts:size": "hardhat size-contracts",
         "contracts:verify:testing:rinkeby": "hardhat contracts-verify --network rinkeby --env testing",
         "contracts:verify:testing": "hardhat contracts-verify --network ropsten --env testing",

--- a/package.json
+++ b/package.json
@@ -108,5 +108,8 @@
         "ts-node": "^10.0.0",
         "typechain": "^5.0.0",
         "typescript": "^4.3.2"
+    },
+    "dependencies": {
+        "prompts": "^2.4.2"
     }
 }

--- a/scripts/deploy-mocks.ts
+++ b/scripts/deploy-mocks.ts
@@ -1,0 +1,112 @@
+import hre from 'hardhat';
+import fs from 'fs';
+import { isValidEnv, addressesDirPath, getAddressesFilePath } from './utils';
+import { calculateDeploymentAddresses } from '../testHelpers/contractAddress';
+import constants from '../testHelpers/constants';
+import packageFile from '../package.json';
+
+const { TOKEN_TYPE } = constants;
+const ethers = hre.ethers;
+
+class DeploymentExecutor {
+    env;
+    erc20;
+    erc721;
+    erc1155;
+    erc1155NonTransferable;
+    maxTip;
+    txOptions;
+
+    constructor() {
+        this.env;
+
+        this.erc20;
+        this.erc721;
+        this.erc1155;
+        this.erc1155NonTransferable;
+
+        this.maxTip = ethers.utils.parseUnits(
+            process.env.MAX_TIP ? String(process.env.MAX_TIP) : '1',
+            'gwei'
+        );
+
+        this.txOptions = {
+            maxPriorityFeePerGas: this.maxTip,
+            gasLimit: 4500000, // our current max contract is around 4.2m gas
+        };
+    }
+
+
+    async deployMockTokens() {
+        // deploys instance of ERC20, ERC721, ERC1155 and ERC1155NonTransferable
+
+        console.log('$ Deploying mock conditional tokens');
+        const MockERC20 = await ethers.getContractFactory('MockERC20');
+        const mockERC20Token = await MockERC20.deploy(this.txOptions);
+        await mockERC20Token.deployed();
+        console.log('$ MockeERC20 contract address ', mockERC20Token.address);
+        const MockERC721 = await ethers.getContractFactory('MockERC721');
+        const mockERC721Token = await MockERC721.deploy(this.txOptions);
+        await mockERC721Token.deployed();
+        console.log('$ MockERC721 contract address ', mockERC721Token.address);
+        const MockERC1155 = await ethers.getContractFactory('MockERC1155');
+        const mockERC1155Token = await MockERC1155.deploy(this.txOptions);
+        await mockERC1155Token.deployed();
+        console.log('$ MockERC1155 contract address ', mockERC1155Token.address);
+        const MockERC1155NonTransferable = await ethers.getContractFactory('ERC1155NonTransferable');
+        const mockERC1155NonTransferableToken = await MockERC1155NonTransferable.deploy(this.txOptions);
+        await mockERC1155NonTransferableToken.deployed();
+        console.log('$ MockERC1155NonTransferable contract address ', mockERC1155NonTransferableToken.address);
+
+        this.erc20 = mockERC20Token.address;
+        this.erc721 = mockERC721Token.address;
+        this.erc1155 = mockERC1155Token.address;
+        this.erc1155NonTransferable = mockERC1155NonTransferableToken.address;
+    }
+
+    writeContracts() {
+        if (!fs.existsSync(addressesDirPath)) {
+            fs.mkdirSync(addressesDirPath);
+        }
+
+        fs.writeFileSync(
+            getAddressesFilePath(hre.network.config.chainId, this.env, "mocks"),
+            JSON.stringify(
+                {
+                    chainId: hre.network.config.chainId,
+                    env: this.env || '',
+                    erc20: this.erc20,
+                    erc721: this.erc721,
+                    erc1155: this.erc1155,
+                    erc1155NonTransferable: this.erc1155NonTransferable
+                },
+                null,
+                2
+            ),
+            'utf-8'
+        );
+    }
+
+}
+
+
+export async function deploy(_env: string): Promise<void> {
+  const env = _env.toLowerCase();
+
+  if (!isValidEnv(env)) {
+    throw new Error(`Env: ${env} is not recognized!`);
+  }
+
+  const executor = new DeploymentExecutor();
+
+//   await executor.deployContracts();
+  await executor.deployMockTokens(); 
+
+//   executor.logContracts();
+  executor.writeContracts();
+
+//   await executor.setDefaults();
+}
+
+
+

--- a/scripts/deploy-mocks.ts
+++ b/scripts/deploy-mocks.ts
@@ -110,9 +110,7 @@ export async function deploy(_env: string): Promise<void> {
                     process.exit()
                 case "y":
                     // just proceed
-                    const executor = new DeploymentExecutor();
-                    await executor.deployMockTokens(); 
-                    executor.writeContracts();
+                    await deployMocks();
                     break;
                 default:
                     console.log('Invalid response');
@@ -120,6 +118,14 @@ export async function deploy(_env: string): Promise<void> {
             }
         }
        await prompt();
+    } else {
+        await deployMocks();
+    }
+
+    async function deployMocks() {
+        const executor = new DeploymentExecutor();
+        await executor.deployMockTokens(); 
+        executor.writeContracts();
     }
 }
 

--- a/scripts/deploy-mocks.ts
+++ b/scripts/deploy-mocks.ts
@@ -69,8 +69,9 @@ class DeploymentExecutor {
             fs.mkdirSync(addressesDirPath);
         }
 
+        const filePath = getAddressesFilePath(hre.network.config.chainId, this.env, "mocks");
         fs.writeFileSync(
-            getAddressesFilePath(hre.network.config.chainId, this.env, "mocks"),
+            filePath,
             JSON.stringify(
                 {
                     chainId: hre.network.config.chainId,
@@ -85,6 +86,7 @@ class DeploymentExecutor {
             ),
             'utf-8'
         );
+        console.log(`Contract addresses written to ${filePath}`)
     }
 
 }

--- a/scripts/deploy-mocks.ts
+++ b/scripts/deploy-mocks.ts
@@ -1,133 +1,139 @@
 import hre from 'hardhat';
 import fs from 'fs';
-import { isValidEnv, addressesDirPath, getAddressesFilePath } from './utils';
-const prompts = require('prompts');
+import {isValidEnv, addressesDirPath, getAddressesFilePath} from './utils';
+import prompts from 'prompts';
 
 const ethers = hre.ethers;
 
 class DeploymentExecutor {
-    env;
-    erc20;
-    erc721;
-    erc1155;
-    erc1155NonTransferable;
-    maxTip;
-    txOptions;
+  env;
+  erc20;
+  erc721;
+  erc1155;
+  erc1155NonTransferable;
+  maxTip;
+  txOptions;
 
-    constructor() {
-        this.env;
+  constructor() {
+    this.env;
 
-        this.erc20;
-        this.erc721;
-        this.erc1155;
-        this.erc1155NonTransferable;
+    this.erc20;
+    this.erc721;
+    this.erc1155;
+    this.erc1155NonTransferable;
 
-        this.maxTip = ethers.utils.parseUnits(
-            process.env.MAX_TIP ? String(process.env.MAX_TIP) : '1',
-            'gwei'
-        );
+    this.maxTip = ethers.utils.parseUnits(
+      process.env.MAX_TIP ? String(process.env.MAX_TIP) : '1',
+      'gwei'
+    );
 
-        this.txOptions = {
-            maxPriorityFeePerGas: this.maxTip,
-            gasLimit: 4500000, // our current max contract is around 4.2m gas
-        };
+    this.txOptions = {
+      maxPriorityFeePerGas: this.maxTip,
+      gasLimit: 4500000, // our current max contract is around 4.2m gas
+    };
+  }
+
+  async deployMockTokens() {
+    // deploys instance of ERC20, ERC721, ERC1155 and ERC1155NonTransferable
+
+    console.log('$ Deploying mock conditional tokens');
+    const MockERC20 = await ethers.getContractFactory('MockERC20');
+    const mockERC20Token = await MockERC20.deploy(this.txOptions);
+    await mockERC20Token.deployed();
+    console.log('$ MockeERC20 contract address ', mockERC20Token.address);
+    const MockERC721 = await ethers.getContractFactory('MockERC721');
+    const mockERC721Token = await MockERC721.deploy(this.txOptions);
+    await mockERC721Token.deployed();
+    console.log('$ MockERC721 contract address ', mockERC721Token.address);
+    const MockERC1155 = await ethers.getContractFactory('MockERC1155');
+    const mockERC1155Token = await MockERC1155.deploy(this.txOptions);
+    await mockERC1155Token.deployed();
+    console.log('$ MockERC1155 contract address ', mockERC1155Token.address);
+    const MockERC1155NonTransferable = await ethers.getContractFactory(
+      'ERC1155NonTransferable'
+    );
+    const mockERC1155NonTransferableToken =
+      await MockERC1155NonTransferable.deploy(this.txOptions);
+    await mockERC1155NonTransferableToken.deployed();
+    console.log(
+      '$ MockERC1155NonTransferable contract address ',
+      mockERC1155NonTransferableToken.address
+    );
+
+    this.erc20 = mockERC20Token.address;
+    this.erc721 = mockERC721Token.address;
+    this.erc1155 = mockERC1155Token.address;
+    this.erc1155NonTransferable = mockERC1155NonTransferableToken.address;
+  }
+
+  writeContracts() {
+    if (!fs.existsSync(addressesDirPath)) {
+      fs.mkdirSync(addressesDirPath);
     }
 
-
-    async deployMockTokens() {
-        // deploys instance of ERC20, ERC721, ERC1155 and ERC1155NonTransferable
-
-        console.log('$ Deploying mock conditional tokens');
-        const MockERC20 = await ethers.getContractFactory('MockERC20');
-        const mockERC20Token = await MockERC20.deploy(this.txOptions);
-        await mockERC20Token.deployed();
-        console.log('$ MockeERC20 contract address ', mockERC20Token.address);
-        const MockERC721 = await ethers.getContractFactory('MockERC721');
-        const mockERC721Token = await MockERC721.deploy(this.txOptions);
-        await mockERC721Token.deployed();
-        console.log('$ MockERC721 contract address ', mockERC721Token.address);
-        const MockERC1155 = await ethers.getContractFactory('MockERC1155');
-        const mockERC1155Token = await MockERC1155.deploy(this.txOptions);
-        await mockERC1155Token.deployed();
-        console.log('$ MockERC1155 contract address ', mockERC1155Token.address);
-        const MockERC1155NonTransferable = await ethers.getContractFactory('ERC1155NonTransferable');
-        const mockERC1155NonTransferableToken = await MockERC1155NonTransferable.deploy(this.txOptions);
-        await mockERC1155NonTransferableToken.deployed();
-        console.log('$ MockERC1155NonTransferable contract address ', mockERC1155NonTransferableToken.address);
-
-        this.erc20 = mockERC20Token.address;
-        this.erc721 = mockERC721Token.address;
-        this.erc1155 = mockERC1155Token.address;
-        this.erc1155NonTransferable = mockERC1155NonTransferableToken.address;
-    }
-
-    writeContracts() {
-        if (!fs.existsSync(addressesDirPath)) {
-            fs.mkdirSync(addressesDirPath);
-        }
-
-        const filePath = getAddressesFilePath(hre.network.config.chainId, this.env, "mocks");
-        fs.writeFileSync(
-            filePath,
-            JSON.stringify(
-                {
-                    chainId: hre.network.config.chainId,
-                    env: this.env || '',
-                    erc20: this.erc20,
-                    erc721: this.erc721,
-                    erc1155: this.erc1155,
-                    erc1155NonTransferable: this.erc1155NonTransferable
-                },
-                null,
-                2
-            ),
-            'utf-8'
-        );
-        console.log(`Contract addresses written to ${filePath}`)
-    }
-
+    const filePath = getAddressesFilePath(
+      hre.network.config.chainId,
+      this.env,
+      'mocks'
+    );
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify(
+        {
+          chainId: hre.network.config.chainId,
+          env: this.env || '',
+          erc20: this.erc20,
+          erc721: this.erc721,
+          erc1155: this.erc1155,
+          erc1155NonTransferable: this.erc1155NonTransferable,
+        },
+        null,
+        2
+      ),
+      'utf-8'
+    );
+    console.log(`Contract addresses written to ${filePath}`);
+  }
 }
 
 export async function deploy(_env: string): Promise<void> {
-    const env = _env.toLowerCase();
+  const env = _env.toLowerCase();
 
-    if (!isValidEnv(env)) {
-        throw new Error(`Env: ${env} is not recognized!`);
-    }
+  if (!isValidEnv(env)) {
+    throw new Error(`Env: ${env} is not recognized!`);
+  }
 
-    if (hre.network.name == 'mainnet') {
-        console.log('You are trying to deploy mock contracts to mainnet');
-        let prompt = async () => {
-            const response = await prompts({
-                type: 'text',
-                name: 'reposnse',
-                message: 'Proceed? [y/n]'
-            });
+  if (hre.network.name == 'mainnet') {
+    console.log('You are trying to deploy mock contracts to mainnet');
+    const prompt = async () => {
+      const response = await prompts({
+        type: 'text',
+        name: 'reposnse',
+        message: 'Proceed? [y/n]',
+      });
 
-            switch (response.reposnse.toLowerCase()) {
-                case "n":
-                    console.log('Aborting')
-                    process.exit()
-                case "y":
-                    // just proceed
-                    await deployMocks();
-                    break;
-                default:
-                    console.log('Invalid response');
-                    await prompt();
-            }
-        }
-       await prompt();
-    } else {
-        await deployMocks();
-    }
+      switch (response.reposnse.toLowerCase()) {
+        case 'n':
+          console.log('Aborting');
+          process.exit();
+        // eslint-disable-next-line no-fallthrough
+        case 'y':
+          // just proceed
+          await deployMocks();
+          break;
+        default:
+          console.log('Invalid response');
+          await prompt();
+      }
+    };
+    await prompt();
+  } else {
+    await deployMocks();
+  }
 
-    async function deployMocks() {
-        const executor = new DeploymentExecutor();
-        await executor.deployMockTokens(); 
-        executor.writeContracts();
-    }
+  async function deployMocks() {
+    const executor = new DeploymentExecutor();
+    await executor.deployMockTokens();
+    executor.writeContracts();
+  }
 }
-
-
-

--- a/scripts/deploy-mocks.ts
+++ b/scripts/deploy-mocks.ts
@@ -1,11 +1,8 @@
 import hre from 'hardhat';
 import fs from 'fs';
 import { isValidEnv, addressesDirPath, getAddressesFilePath } from './utils';
-import { calculateDeploymentAddresses } from '../testHelpers/contractAddress';
-import constants from '../testHelpers/constants';
-import packageFile from '../package.json';
+const prompts = require('prompts');
 
-const { TOKEN_TYPE } = constants;
 const ethers = hre.ethers;
 
 class DeploymentExecutor {
@@ -91,23 +88,39 @@ class DeploymentExecutor {
 
 }
 
-
 export async function deploy(_env: string): Promise<void> {
-  const env = _env.toLowerCase();
+    const env = _env.toLowerCase();
 
-  if (!isValidEnv(env)) {
-    throw new Error(`Env: ${env} is not recognized!`);
-  }
+    if (!isValidEnv(env)) {
+        throw new Error(`Env: ${env} is not recognized!`);
+    }
 
-  const executor = new DeploymentExecutor();
+    if (hre.network.name == 'mainnet') {
+        console.log('You are trying to deploy mock contracts to mainnet');
+        let prompt = async () => {
+            const response = await prompts({
+                type: 'text',
+                name: 'reposnse',
+                message: 'Proceed? [y/n]'
+            });
 
-//   await executor.deployContracts();
-  await executor.deployMockTokens(); 
-
-//   executor.logContracts();
-  executor.writeContracts();
-
-//   await executor.setDefaults();
+            switch (response.reposnse.toLowerCase()) {
+                case "n":
+                    console.log('Aborting')
+                    process.exit()
+                case "y":
+                    // just proceed
+                    const executor = new DeploymentExecutor();
+                    await executor.deployMockTokens(); 
+                    executor.writeContracts();
+                    break;
+                default:
+                    console.log('Invalid response');
+                    await prompt();
+            }
+        }
+       await prompt();
+    }
 }
 
 

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -12,8 +12,8 @@ export function isValidEnv(env: string): boolean {
   return availableEnvironments.some((e) => e == env);
 }
 
-export function getAddressesFilePath(chainId: number, env?: string): string {
+export function getAddressesFilePath(chainId: number, env?: string, suffix?: string): string {
   return `${addressesDirPath}/${chainId}${
     env ? `-${env.toLowerCase()}` : ''
-  }.json`;
+  }${suffix ? `-${suffix}` : ''}.json`;
 }

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -12,8 +12,12 @@ export function isValidEnv(env: string): boolean {
   return availableEnvironments.some((e) => e == env);
 }
 
-export function getAddressesFilePath(chainId: number, env?: string, suffix?: string): string {
-  return `${addressesDirPath}/${chainId}${
-    env ? `-${env.toLowerCase()}` : ''
-  }${suffix ? `-${suffix}` : ''}.json`;
+export function getAddressesFilePath(
+  chainId: number,
+  env?: string,
+  suffix?: string
+): string {
+  return `${addressesDirPath}/${chainId}${env ? `-${env.toLowerCase()}` : ''}${
+    suffix ? `-${suffix}` : ''
+  }.json`;
 }


### PR DESCRIPTION
Added script to deploy mock tokens (ERC20, ERC721, ERC1155 and ERC1155NonTransferable).

- It works on all networks, however if trying to deploy to mainnet, user needs to explicitly confirm it.
- It writes the address to file in folder `/addresses/`
- I added two npm scripts to use it