### PR TITLE
VKL-01C: Statement Execution Optimization

### DIFF
--- a/contracts/Cashier.sol
+++ b/contracts/Cashier.sol
@@ -402,10 +402,11 @@ contract Cashier is ICashier, ReentrancyGuard, Ownable, Pausable {
 
         _released = _amount > 0;
 
-        IVoucherKernel(voucherKernel).setDepositsReleased(
-            _voucherDetails.tokenIdVoucher, _to, _amount
-        );
-
+        if (_released) {
+            IVoucherKernel(voucherKernel).setDepositsReleased(
+                _voucherDetails.tokenIdVoucher, _to, _amount
+            );
+        }
     }
 
     /**

--- a/contracts/VoucherKernel.sol
+++ b/contracts/VoucherKernel.sol
@@ -719,6 +719,7 @@ contract VoucherKernel is IVoucherKernel, Ownable, Pausable, ReentrancyGuard {
 
     /**
      * @notice Mark voucher token that the deposits were released
+     * @dev    Currently Cashier makes a check that _amount > 0. If onlyFromCashier is ever removed, this function should check that _amount > 0
      * @param _tokenIdVoucher   ID of the voucher token
      * @param _to               recipient, one of {ISSUER, HOLDER, POOL}
      * @param _amount           amount that was released in the transaction


### PR DESCRIPTION
FIx #332 

Three things to note:
- I did not use require, since that would revert transaction. In most cases when `withdraw` is called, at least for some party amount is zero, and imposing that check would render `withdraw` useless
- I considered just putting lines 735 - 740 in if conditional that would execute only if amount > 0 (this is what was proposed). That would result in `vouchersStatus[_tokenIdVoucher].depositReleased.status` still being updated. Although this is not wrong per se, this would result in different states depending on whether `withdraw` is called or if `withdrawSingle` is callled for each entity.
In `withdraw`,  it would seem as if deposit was released to all three entities, while `withdrawSingle` would revert if there was nothing to be withdrawn and therefore `vouchersStatus[_tokenIdVoucher].depositReleased.status` would not be updated. I decided to do it in a way, that calling withdraw or withdrawSIngle three times result in same state.
- I could impose the check `_amount > 0` at very begining of `setDepositsReleased` and just return if `amount ==0`, but I decided to actually put that check into `Cashier` to avoid a call to VoucherKernel contract at all. I added a comment in `setDepositsReleased` so if at any point  `onlyFromCashier` is removed that amount tcheck should be put in place.