### PR TITLE
Remediate GAT-02C: Sub-Optimal Storage Read

### DIFF
--- a/contracts/Gate.sol
+++ b/contracts/Gate.sol
@@ -108,7 +108,7 @@ contract Gate is IGate, Ownable, Pausable {
      * @return threshold that may be checked when a user commits using a conditional token
      */
     function getConditionalCommitInfo(uint256 _tokenIdSupply) external view returns (uint256, Condition, uint256) {
-        ConditionalCommitInfo memory conditionalCommitInfo = voucherSetToConditionalCommit[_tokenIdSupply];
+        ConditionalCommitInfo storage conditionalCommitInfo = voucherSetToConditionalCommit[_tokenIdSupply];
         return (
             conditionalCommitInfo.conditionalTokenId,
             conditionalCommitInfo.condition,


### PR DESCRIPTION
This is a view function that is NOT called internally, so there is no gas cost. I'm making this change just to satisfy the auditors.