### PR TITLE
Zip and Upload entire coverage directory

### DIFF
--- a/.github/workflows/code-coverage-check.yaml
+++ b/.github/workflows/code-coverage-check.yaml
@@ -2,7 +2,7 @@ name: Code Coverage Check
 
 on:
   push:
-    branches: [ gha-zip-and-upload-complete-coverage ]
+    branches: [ main ]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/code-coverage-check.yaml
+++ b/.github/workflows/code-coverage-check.yaml
@@ -2,7 +2,7 @@ name: Code Coverage Check
 
 on:
   push:
-    branches: [ main ]
+    branches: [ gha-zip-and-upload-complete-coverage ]
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -35,4 +35,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: code-coverage-report
-          path: coverage/index.html
+          path: coverage/


### PR DESCRIPTION
The current code coverage is an `.html` file with less information.
In this PR, I am creating a Zip file of the entire `coverage` directory and uploading it to Github.

An example of the new coverage file is here https://github.com/bosonprotocol/contracts/actions/runs/1961813441