### PR TITLE
Remediate VKL-01S

### DIFF
--- a/contracts/VoucherKernel.sol
+++ b/contracts/VoucherKernel.sol
@@ -24,6 +24,9 @@ contract VoucherKernel is IVoucherKernel, Ownable, Pausable, ReentrancyGuard {
     using Address for address;
     using SafeMath for uint256;
 
+    //constant for setting complain and cancel periods
+    uint256 internal constant WEEK = 7 * 1 days;
+
     //ERC1155 contract representing voucher sets
     address private voucherSetTokenAddress;
 
@@ -203,10 +206,8 @@ contract VoucherKernel is IVoucherKernel, Ownable, Pausable, ReentrancyGuard {
         emit LogVoucherSetTokenContractSet(_voucherSetTokenAddress, msg.sender);
         emit LogVoucherTokenContractSet(_voucherTokenAddress, msg.sender);
 
-        uint256 _complainPeriod = 7 * 1 days;
-        uint256 _cancelFaultPeriod = 7 * 1 days;
-        setComplainPeriod(_complainPeriod);
-        setCancelFaultPeriod(_cancelFaultPeriod);
+        setComplainPeriod(WEEK);
+        setCancelFaultPeriod(WEEK);
     }
 
     /**

--- a/contracts/VoucherKernel.sol
+++ b/contracts/VoucherKernel.sol
@@ -205,11 +205,8 @@ contract VoucherKernel is IVoucherKernel, Ownable, Pausable, ReentrancyGuard {
 
         uint256 _complainPeriod = 7 * 1 days;
         uint256 _cancelFaultPeriod = 7 * 1 days;
-        complainPeriod = _complainPeriod;
-        cancelFaultPeriod = _cancelFaultPeriod;
-
-        emit LogComplainPeriodChanged(_complainPeriod, msg.sender);
-        emit LogCancelFaultPeriodChanged(_cancelFaultPeriod, msg.sender);
+        setComplainPeriod(_complainPeriod);
+        setCancelFaultPeriod(_cancelFaultPeriod);
     }
 
     /**
@@ -917,8 +914,7 @@ contract VoucherKernel is IVoucherKernel, Ownable, Pausable, ReentrancyGuard {
      * @param _complainPeriod   the new value for complain period (in number of seconds)
      */
     function setComplainPeriod(uint256 _complainPeriod)
-        external
-        override
+        public
         onlyOwner
     {
         complainPeriod = _complainPeriod;
@@ -931,8 +927,7 @@ contract VoucherKernel is IVoucherKernel, Ownable, Pausable, ReentrancyGuard {
      * @param _cancelFaultPeriod   the new value for cancelOrFault period (in number of seconds)
      */
     function setCancelFaultPeriod(uint256 _cancelFaultPeriod)
-        external
-        override
+        public
         onlyOwner
     {
         cancelFaultPeriod = _cancelFaultPeriod;

--- a/contracts/VoucherKernel.sol
+++ b/contracts/VoucherKernel.sol
@@ -916,6 +916,7 @@ contract VoucherKernel is IVoucherKernel, Ownable, Pausable, ReentrancyGuard {
      */
     function setComplainPeriod(uint256 _complainPeriod)
         public
+        override
         onlyOwner
     {
         complainPeriod = _complainPeriod;
@@ -929,6 +930,7 @@ contract VoucherKernel is IVoucherKernel, Ownable, Pausable, ReentrancyGuard {
      */
     function setCancelFaultPeriod(uint256 _cancelFaultPeriod)
         public
+        override
         onlyOwner
     {
         cancelFaultPeriod = _cancelFaultPeriod;

--- a/contracts/interfaces/IVoucherKernel.sol
+++ b/contracts/interfaces/IVoucherKernel.sol
@@ -152,6 +152,12 @@ interface IVoucherKernel {
     ) external;
 
     /**
+     * @notice Set the general cancelOrFault period, should be used sparingly as it has significant consequences. Here done simply for demo purposes.
+     * @param _cancelFaultPeriod   the new value for cancelOrFault period (in number of seconds)
+     */
+    function setCancelFaultPeriod(uint256 _cancelFaultPeriod) external;
+
+    /**
      * @notice Set the address of the Boson Router contract
      * @param _bosonRouterAddress   The address of the BR contract
      */
@@ -175,6 +181,12 @@ interface IVoucherKernel {
      */
     function setVoucherSetTokenAddress(address _voucherSetTokenAddress)
         external;
+
+    /**
+     * @notice Set the general complain period, should be used sparingly as it has significant consequences. Here done simply for demo purposes.
+     * @param _complainPeriod   the new value for complain period (in number of seconds)
+     */
+    function setComplainPeriod(uint256 _complainPeriod) external;
 
     /**
      * @notice Get the promise ID at specific index

--- a/contracts/interfaces/IVoucherKernel.sol
+++ b/contracts/interfaces/IVoucherKernel.sol
@@ -152,12 +152,6 @@ interface IVoucherKernel {
     ) external;
 
     /**
-     * @notice Set the general cancelOrFault period, should be used sparingly as it has significant consequences. Here done simply for demo purposes.
-     * @param _cancelFaultPeriod   the new value for cancelOrFault period (in number of seconds)
-     */
-    function setCancelFaultPeriod(uint256 _cancelFaultPeriod) external;
-
-    /**
      * @notice Set the address of the Boson Router contract
      * @param _bosonRouterAddress   The address of the BR contract
      */
@@ -181,12 +175,6 @@ interface IVoucherKernel {
      */
     function setVoucherSetTokenAddress(address _voucherSetTokenAddress)
         external;
-
-    /**
-     * @notice Set the general complain period, should be used sparingly as it has significant consequences. Here done simply for demo purposes.
-     * @param _complainPeriod   the new value for complain period (in number of seconds)
-     */
-    function setComplainPeriod(uint256 _complainPeriod) external;
 
     /**
      * @notice Get the promise ID at specific index


### PR DESCRIPTION
The remediation is different from what is suggested in the audit, but it makes the code more legible. The complainPeriod and cancelFaultPeriod can't be constants (as suggested by the auditors) because they need to be settable using the `setComplainPeriod` and `setCancelFaultPeriod` functions. These functions are needed so that the periods can be set to lower values for testing on testnet. Otherwise, we would have to wait two weeks to test some scenarios.  

As discussed, the set functions are now being called from the constructor. The set functions emit the events. Normally when calling a function from within the same contract, the function visibility is public. It is also necessary to change the set function visibility to public because it's not possible to call an external function on the same contract from the constructor.I made the function visibility change, but this necessitated removing the functions from the IVoucherKernel interface. I ran the gas reporter in the before and after situation by executing two test cases -- one that tests `setComplainPeriod` and one that calls `setCancelPeriod`. Both test cases cause the constructor to be called because the contracts are redeployed before each test case.

The result is that after this change, the gas used by the constructor goes UP by 4868. I've attached the gas reports. The GasReport-external-setters-not-called-from-constructor.txt represents the original situation before the change. Based on the gas reports and the fact that the issue pointed out by the auditors is to optimize gas, I'm not sure it is worth making this change. On the other hand, the constructor code is simplified.

[GasReport-external-setters-not-called-from-constructor.txt](https://github.com/bosonprotocol/contracts/files/8221611/GasReport-external-setters-not-called-from-constructor.txt)
[GasReport-public-setters-called-from-constructor.txt](https://github.com/bosonprotocol/contracts/files/8221612/GasReport-public-setters-called-from-constructor.txt)
