### PR TITLE
VoucherKernel.getTotalDeposits fix

### DIFF
--- a/contracts/VoucherKernel.sol
+++ b/contracts/VoucherKernel.sol
@@ -735,7 +735,7 @@ contract VoucherKernel is IVoucherKernel, Ownable, Pausable, ReentrancyGuard {
 
         vouchersStatus[_tokenIdVoucher].depositReleased.releasedAmount = uint248(uint256(vouchersStatus[_tokenIdVoucher].depositReleased.releasedAmount).add(_amount));
 
-        if (vouchersStatus[_tokenIdVoucher].depositReleased.releasedAmount == getTotalDeposits(_tokenIdVoucher)) {
+        if (vouchersStatus[_tokenIdVoucher].depositReleased.releasedAmount == getTotalDepositsForVoucher(_tokenIdVoucher)) {
             vouchersStatus[_tokenIdVoucher].isDepositsReleased = true;
             emit LogFundsReleased(_tokenIdVoucher, 1); 
         }        
@@ -1033,7 +1033,7 @@ contract VoucherKernel is IVoucherKernel, Ownable, Pausable, ReentrancyGuard {
      * @notice Get the sum of buyer and seller deposit for the voucher
      * @param _tokenIdVoucher   ID of the voucher token
      */
-    function getTotalDeposits(uint256 _tokenIdVoucher)
+    function getTotalDepositsForVoucher(uint256 _tokenIdVoucher)
         internal
         view
         returns (

--- a/contracts/VoucherKernel.sol
+++ b/contracts/VoucherKernel.sol
@@ -1029,14 +1029,19 @@ contract VoucherKernel is IVoucherKernel, Ownable, Pausable, ReentrancyGuard {
         );
     }
 
-    function getTotalDeposits(uint256 _tokenIdSupply)
+    /**
+     * @notice Get the sum of buyer and seller deposit for the voucher
+     * @param _tokenIdVoucher   ID of the voucher token
+     */
+    function getTotalDeposits(uint256 _tokenIdVoucher)
         internal
         view
         returns (
             uint256
         )
     {
-        bytes32 promiseKey = ordersPromise[_tokenIdSupply];
+        bytes32 promiseKey = getPromiseIdFromVoucherId(_tokenIdVoucher);
+        
         return promises[promiseKey].depositSe.add(promises[promiseKey].depositBu);
     }
 

--- a/test/3_1_withdrawals_per_entity.ts
+++ b/test/3_1_withdrawals_per_entity.ts
@@ -478,10 +478,7 @@ describe('Cashier withdrawals ', () => {
 
         const recipients = [...depositRecipients, ...paymentRecipients];
 
-        // let lastDepositRecepient = isEntityRecipient(
-        //   [...depositRecipients, ...paymentRecipients],
-        //   Entity[-1]
-        // )
+        // determine who is the last entity that should receive at leas some part of the deposit
         let lastDepositRecepient;
         for (const entity of [...Object.keys(Entity)].reverse()) {
           if (isEntityRecipient(recipients, entity)) {

--- a/test/3_1_withdrawals_per_entity.ts
+++ b/test/3_1_withdrawals_per_entity.ts
@@ -399,6 +399,16 @@ describe('Cashier withdrawals ', () => {
                   }
                 );
 
+                eventUtils.assertEventEmitted(
+                  txReceipt,
+                  VoucherKernel_Factory,
+                  eventNames.LOG_FUNDS_RELEASED,
+                  (ev) => {
+                    assert.isTrue(ev._tokenIdVoucher.eq(voucherID));
+                    assert.equal(ev._type, 0); // 0 == withdraw
+                  }
+                );
+
                 if (ethTransfers && paymentWithdrawal) {
                   // only eth transfers emit LOG_WITHDRAWAL. If price was in TKN, paymentWithdrawal == null and no adjustment is needed
                   eventUtils.assertEventEmitted(
@@ -466,13 +476,22 @@ describe('Cashier withdrawals ', () => {
           );
         }
 
+        const recipients = [...depositRecipients, ...paymentRecipients];
+
+        // let lastDepositRecepient = isEntityRecipient(
+        //   [...depositRecipients, ...paymentRecipients],
+        //   Entity[-1]
+        // )
+        let lastDepositRecepient;
+        for (const entity of [...Object.keys(Entity)].reverse()) {
+          if (isEntityRecipient(recipients, entity)) {
+            lastDepositRecepient = entity;
+            break;
+          }
+        }
+
         for (const [entity, entityIndex] of Object.entries(Entity)) {
-          if (
-            isEntityRecipient(
-              [...depositRecipients, ...paymentRecipients],
-              entity
-            )
-          ) {
+          if (isEntityRecipient(recipients, entity)) {
             const withdrawTx = await utils.withdrawSingle(
               voucherID,
               entityIndex,
@@ -496,6 +515,37 @@ describe('Cashier withdrawals ', () => {
                 });
               }
             );
+
+            if (i == 0) {
+              // deposits not released before, event should be emitted here
+              let expectedTypeIndex = 0;
+              const expectedTypes = [];
+              if (isEntityRecipient(paymentRecipients, entity))
+                expectedTypes.push(0);
+              if (entity == lastDepositRecepient) expectedTypes.push(1);
+              if (expectedTypes.length > 0) {
+                eventUtils.assertEventEmitted(
+                  txReceipt,
+                  VoucherKernel_Factory,
+                  eventNames.LOG_FUNDS_RELEASED,
+                  (ev) => {
+                    assert.isTrue(ev._tokenIdVoucher.eq(voucherID));
+
+                    assert.equal(ev._type, expectedTypes[expectedTypeIndex++]); // 0 == withdraw, 1 == deposit
+                  }
+                );
+              }
+            } else if (entity == lastDepositRecepient) {
+              eventUtils.assertEventEmitted(
+                txReceipt,
+                VoucherKernel_Factory,
+                eventNames.LOG_FUNDS_RELEASED,
+                (ev) => {
+                  assert.isTrue(ev._tokenIdVoucher.eq(voucherID));
+                  assert.equal(ev._type, 1); // 1 == deposit
+                }
+              );
+            }
 
             if (
               ethTransfers &&

--- a/test/3_1_withdrawals_per_entity.ts
+++ b/test/3_1_withdrawals_per_entity.ts
@@ -405,7 +405,7 @@ describe('Cashier withdrawals ', () => {
                   eventNames.LOG_FUNDS_RELEASED,
                   (ev) => {
                     assert.isTrue(ev._tokenIdVoucher.eq(voucherID));
-                    assert.equal(ev._type, 0); // 0 == withdraw
+                    assert.equal(ev._type, 0); // 0 == payment
                   }
                 );
 
@@ -531,7 +531,7 @@ describe('Cashier withdrawals ', () => {
                   (ev) => {
                     assert.isTrue(ev._tokenIdVoucher.eq(voucherID));
 
-                    assert.equal(ev._type, expectedTypes[expectedTypeIndex++]); // 0 == withdraw, 1 == deposit
+                    assert.equal(ev._type, expectedTypes[expectedTypeIndex++]); // 0 == payment, 1 == deposit
                   }
                 );
               }

--- a/test/3_withdrawals.ts
+++ b/test/3_withdrawals.ts
@@ -380,6 +380,16 @@ describe('Cashier withdrawals ', () => {
                 }
               );
 
+              eventUtils.assertEventEmitted(
+                txReceipt,
+                VoucherKernel_Factory,
+                eventNames.LOG_FUNDS_RELEASED,
+                (ev) => {
+                  assert.isTrue(ev._tokenIdVoucher.eq(voucherID));
+                  assert.equal(ev._type, 0); // 0 == withdraw
+                }
+              );
+
               if (ethTransfers && paymentWithdrawal) {
                 // only eth transfers emit LOG_WITHDRAWAL. If price was in TKN, paymentWithdrawal == null and no adjustment is needed
                 eventUtils.assertEventEmitted(
@@ -453,6 +463,31 @@ describe('Cashier withdrawals ', () => {
             });
           }
         );
+
+        if (i == 0) {
+          // deposits not released before, event should be emitted here
+          let expectedType = 0;
+          eventUtils.assertEventEmitted(
+            txReceipt,
+            VoucherKernel_Factory,
+            eventNames.LOG_FUNDS_RELEASED,
+            (ev) => {
+              assert.isTrue(ev._tokenIdVoucher.eq(voucherID));
+
+              assert.equal(ev._type, expectedType++); // 0 == withdraw, 1 == deposit
+            }
+          );
+        } else {
+          eventUtils.assertEventEmitted(
+            txReceipt,
+            VoucherKernel_Factory,
+            eventNames.LOG_FUNDS_RELEASED,
+            (ev) => {
+              assert.isTrue(ev._tokenIdVoucher.eq(voucherID));
+              assert.equal(ev._type, 1); // 1 == deposit
+            }
+          );
+        }
 
         if (ethTransfers && (depositWithdrawal || !paymentWithdrawn)) {
           // only eth transfers emit LOG_WITHDRAWAL

--- a/test/3_withdrawals.ts
+++ b/test/3_withdrawals.ts
@@ -386,7 +386,7 @@ describe('Cashier withdrawals ', () => {
                 eventNames.LOG_FUNDS_RELEASED,
                 (ev) => {
                   assert.isTrue(ev._tokenIdVoucher.eq(voucherID));
-                  assert.equal(ev._type, 0); // 0 == withdraw
+                  assert.equal(ev._type, 0); // 0 == payment
                 }
               );
 
@@ -473,8 +473,7 @@ describe('Cashier withdrawals ', () => {
             eventNames.LOG_FUNDS_RELEASED,
             (ev) => {
               assert.isTrue(ev._tokenIdVoucher.eq(voucherID));
-
-              assert.equal(ev._type, expectedType++); // 0 == withdraw, 1 == deposit
+              assert.equal(ev._type, expectedType++); // 0 == payment, 1 == deposit
             }
           );
         } else {


### PR DESCRIPTION
 `VoucherKernel.getTotalDeposits` expected that `tokenIdSupply` is passed in, but there was a mistake and the `voucherId` was passed in.

I renamed the function to `getTotalDepositsForVoucher` to be clear it depends on voucher, not on voucher set and modified it to return correct values.

A consequence of bug was, that `LogFundsReleased` was not emitted when it should be. I noticed that this was not properly tested so I also added missing checks to `3_withdrawals` and `3_1_withdrawals_per_entity`