### PR TITLE
Deployment script without ERC1155NonTransferable

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,21 +110,21 @@ This makes the BOSON test token deployed on Rinkeby (0xEDa08eF1c6ff51Ca7Fd681295
 
 #### Special deployments
 
-The following instructions assume you have started a hardhat node (forked or not) using the local node instructions above.  
+The following instructions assume you have started a hardhat node (forked or not) using the local node instructions above. If you want to deploy the contracts to testnets or mainnet just replace `localhost` with the desired network. 
 Calling `npx hardhat deploy` will deploy the protocol contracts. Beside that we provide addtional utility script for the following deployment cases:
 
 - Deploy all protocol contracts and ERC1155NonTransferable (equivalent to v1.0 deployment script)
 
   ```
-  npx hardhat deploy-with-erc1155
+  npx hardhat deploy-with-erc1155 --network localhost
   ```
 - Deploy only ERC1155NonTransferable and set the metadata uri defined in `.env` file
   ```
-  npx hardhat deploy-erc1155-only
+  npx hardhat deploy-erc1155-only --network localhost
   ```
 - Deploy a set of mock token contracts ERC20, ERC721, ERC1155 and ERC1155NonTransferable which can be used to test conditional commit
   ```
-  npx hardhat deploy-mocks
+  npx hardhat deploy-mocks --network localhost
   ```
 - Deploy a Gate contract on a provided network
   - First run the deploy task to deploy the Boson Protocol contracts to your local node, as described above

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ This makes the BOSON test token deployed on Rinkeby (0xEDa08eF1c6ff51Ca7Fd681295
 
 #### Special deployments
 
+The following instructions assume you have started a hardhat node (forked or not) using the local node instructions above.  
 Calling `npx hardhat deploy` will deploy the protocol contracts. Beside that we provide addtional utility script for the following deployment cases:
 
 - Deploy all protocol contracts and ERC1155NonTransferable (equivalent to v1.0 deployment script)
@@ -126,9 +127,20 @@ Calling `npx hardhat deploy` will deploy the protocol contracts. Beside that we 
   npx hardhat deploy-mocks
   ```
 - Deploy a Gate contract on a provided network
-  ```
-  npx hardhat deploy-gate
-  ```
+  - First run the deploy task to deploy the Boson Protocol contracts to your local node, as described above
+  - Then run deploy-mocks, as described above
+  - Provide values for the folowing properties in your .env file
+    ```
+    BOSON_ROUTER_ADDRESS=0000000000000000000000000000000000000000
+    CONDITIONAL_TOKEN_ADDRESS=0000000000000000000000000000000000000000
+    #Must be 0 (FUNGIBLE_TOKEN - ERC20), 1 (NONFUNGIBLE_TOKEN - ERC721), or 2 (MULTI_TOKEN - ERC1155)
+    CONDITIONAL_TOKEN_TYPE=x
+    ```
+    The Boson Router address and conditional token mock addresses can be found in the corresponding file in the addresses directory. For local deployments, the Boson Router address will be written to a file called 1.json (deploy). The mock conditional token addresses can be found in 1-mocks.json
+  - Then run
+    ```
+    npx hardhat deploy-gate --network localhost
+    ```
 
 ---
 ### Test

--- a/README.md
+++ b/README.md
@@ -18,11 +18,15 @@ it, please see the [documentation site](https://docs.bosonprotocol.io/).
 
 - [Local Development](#local-development)
   - [Prerequisites](#prerequisites)
-  - [Build](#build)
-  - [Run](#run)
+  - [Installation](#installation)
+    - [Forking Rinkeby to localnode](#forking-rinkeby-to-localnode)
+    - [Special deployments](#special-deployments)
   - [Test](#test)
+    - [Testing with DAI](#testing-with-dai)
+    - [Unit Tests](#unit-tests)
+    - [Coverage](#coverage)
   - [Code Linting & Formatting](#code-linting--formatting)
-- [Documentation](#documentation)  
+- [Documentation](#documentation)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -102,6 +106,29 @@ npx hardhat deploy --network localhost
 ```
 
 This makes the BOSON test token deployed on Rinkeby (0xEDa08eF1c6ff51Ca7Fd681295797102c1B84606c) and the official DAI token deployed on Rinkeby (0x6A9865aDE2B6207dAAC49f8bCba9705dEB0B0e6D) available to your local hardhat chain.
+
+
+#### Special deployments
+
+Calling `npx hardhat deploy` will deploy the protocol contracts. Beside that we provide addtional utility script for the following deployment cases:
+
+- Deploy all protocol contracts and ERC1155NonTransferable (equivalent to v1.0 deployment script)
+
+  ```
+  npx hardhat deploy-with-erc1155
+  ```
+- Deploy only ERC1155NonTransferable and set the metadata uri defined in `.env` file
+  ```
+  npx hardhat deploy-erc1155-only
+  ```
+- Deploy a set of mock token contracts ERC20, ERC721, ERC1155 and ERC1155NonTransferable which can be used to test conditional commit
+  ```
+  npx hardhat deploy-mocks
+  ```
+- Deploy a Gate contract on a provided network
+  ```
+  npx hardhat deploy-gate
+  ```
 
 ---
 ### Test

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -52,7 +52,6 @@ task("deploy-mocks", "Deploy mock conditional token contracts (ERC20, ERC721, ER
 		await deploy(env);
 	})
 
-
 task("contracts-verify", "Verify already deployed contracts. Bear in mind that at least couple of blocks should be mined before execution!")
 	.addOptionalParam("env", "(Optional) Provide additional context on which environment the contracts are deployed to: production, staging or testing", "")
 	.setAction(async ({env}) => {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -24,10 +24,24 @@ const lazyImport = async (module) => {
 	return await import(module);
 }
 
-task("deploy", "Deploy contracts on a provided network")
+task("deploy", "Deploy protocol contracts on a provided network")
 	.addOptionalParam("env", "(Optional) Provide additional context on which environment the contracts are deployed to: production, staging or testing", "")
 	.setAction( async ({env}) => {
 		const { deploy } = await lazyImport('./scripts/deploy')
+		await deploy(env);
+	})
+
+task("deploy-with-erc1155", "Deploy protocol contracts and a ERC1155NonTransferable contract on a provided network [== v1.0 deployment script]")
+	.addOptionalParam("env", "(Optional) Provide additional context on which environment the contracts are deployed to: production, staging or testing", "")
+	.setAction( async ({env}) => {
+		const { deploy } = await lazyImport('./scripts/deploy-legacy')
+		await deploy(env);
+	})
+
+task("deploy-erc1155-only", "Deploy a ERC1155NonTransferable contract on a provided network")
+	.addOptionalParam("env", "(Optional) Provide additional context on which environment the contracts are deployed to: production, staging or testing", "")
+	.setAction( async ({env}) => {
+		const { deploy } = await lazyImport('./scripts/deploy-erc1155-non-transferable')
 		await deploy(env);
 	})
 

--- a/scripts/deploy-erc1155-non-transferable.ts
+++ b/scripts/deploy-erc1155-non-transferable.ts
@@ -1,10 +1,6 @@
-//AssetRegistry not used in demo-app
-//const AssetRegistry = artifacts.require("AssetRegistry");
-
 import hre from 'hardhat';
 import fs from 'fs';
 import {isValidEnv, addressesDirPath, getAddressesFilePath} from './utils';
-import {calculateDeploymentAddresses} from '../testHelpers/contractAddress';
 import packageFile from '../package.json';
 
 const ethers = hre.ethers;

--- a/scripts/deploy-erc1155-non-transferable.ts
+++ b/scripts/deploy-erc1155-non-transferable.ts
@@ -33,14 +33,15 @@ class DeploymentExecutor {
 
   async deployContracts() {
     const signers = await ethers.getSigners();
-    let [, ccTokenDeployer] = signers;
-    const [primaryDeployer] = signers;
+    let ccTokenDeployer;
 
     if (
       process.env.PROTOCOL_DEPLOYER_PRIVATE_KEY ==
       process.env.CC_TOKEN_DEPLOYER_PRIVATE_KEY
     ) {
-      ccTokenDeployer = primaryDeployer;
+      [ccTokenDeployer] = signers;
+    } else {
+      [, ccTokenDeployer] = signers;
     }
 
     const ERC1155NonTransferable = await ethers.getContractFactory(

--- a/scripts/deploy-erc1155-non-transferable.ts
+++ b/scripts/deploy-erc1155-non-transferable.ts
@@ -76,16 +76,18 @@ class DeploymentExecutor {
     );
   }
 
-  writeContracts() {
+  async writeContracts() {
     if (!fs.existsSync(addressesDirPath)) {
       fs.mkdirSync(addressesDirPath);
     }
 
+    const chainId = (await hre.ethers.provider.getNetwork()).chainId;
+
     fs.writeFileSync(
-      getAddressesFilePath(hre.network.config.chainId, this.env, 'erc1155nt'),
+      getAddressesFilePath(chainId, this.env, 'erc1155nt'),
       JSON.stringify(
         {
-          chainId: hre.network.config.chainId,
+          chainId: chainId,
           env: this.env || '',
           protocolVersion: packageFile.version,
           erc1155NonTransferable: this.erc1155NonTransferable.address,
@@ -110,5 +112,5 @@ export async function deploy(_env: string): Promise<void> {
   await executor.deployContracts();
 
   executor.logContracts();
-  executor.writeContracts();
+  await executor.writeContracts();
 }

--- a/scripts/deploy-erc1155-non-transferable.ts
+++ b/scripts/deploy-erc1155-non-transferable.ts
@@ -1,0 +1,117 @@
+//AssetRegistry not used in demo-app
+//const AssetRegistry = artifacts.require("AssetRegistry");
+
+import hre from 'hardhat';
+import fs from 'fs';
+import {isValidEnv, addressesDirPath, getAddressesFilePath} from './utils';
+import {calculateDeploymentAddresses} from '../testHelpers/contractAddress';
+import packageFile from '../package.json';
+
+const ethers = hre.ethers;
+
+/**
+ * Class DeploymentExecutor.
+ *
+ * @class DeploymentExecutor
+ */
+class DeploymentExecutor {
+  env;
+  erc1155NonTransferable;
+  maxTip;
+  txOptions;
+
+  constructor() {
+    this.env;
+    this.erc1155NonTransferable;
+
+    this.maxTip = ethers.utils.parseUnits(
+      process.env.MAX_TIP ? String(process.env.MAX_TIP) : '1',
+      'gwei'
+    );
+
+    this.txOptions = {
+      maxPriorityFeePerGas: this.maxTip,
+      gasLimit: 4500000, // our current max contract is around 4.2m gas
+    };
+  }
+
+  async deployContracts() {
+    const signers = await ethers.getSigners();
+    let [, ccTokenDeployer] = signers;
+    const [primaryDeployer] = signers;
+
+    if (
+      process.env.PROTOCOL_DEPLOYER_PRIVATE_KEY ==
+      process.env.CC_TOKEN_DEPLOYER_PRIVATE_KEY
+    ) {
+      ccTokenDeployer = primaryDeployer;
+    }
+
+    const ERC1155NonTransferable = await ethers.getContractFactory(
+      'ERC1155NonTransferable'
+    );
+
+    //ERC1155NonTransferrable is a Conditional Commit token and should be deployed from a separate address
+    const ERC1155NonTransferableAsOtherSigner =
+      ERC1155NonTransferable.connect(ccTokenDeployer);
+
+    //ERC1155NonTransferrable is a Conditional Commit token and should be deployed from a separate address
+    this.erc1155NonTransferable =
+      await ERC1155NonTransferableAsOtherSigner.deploy(
+        process.env.CONDITIONAL_COMMIT_TOKEN_METADATA_URI,
+        this.txOptions
+      );
+
+    await this.erc1155NonTransferable.deployed();
+
+    console.log(
+      '$ ERC1155NonTransferable URI ',
+      'set to :',
+      await this.erc1155NonTransferable.uri(1)
+    );
+  }
+
+  logContracts() {
+    console.log(
+      'ERC1155NonTransferable Contract Address: %s from deployer address %s',
+      this.erc1155NonTransferable.address,
+      this.erc1155NonTransferable.deployTransaction.from
+    );
+  }
+
+  writeContracts() {
+    if (!fs.existsSync(addressesDirPath)) {
+      fs.mkdirSync(addressesDirPath);
+    }
+
+    fs.writeFileSync(
+      getAddressesFilePath(hre.network.config.chainId, this.env, 'erc1155nt'),
+      JSON.stringify(
+        {
+          chainId: hre.network.config.chainId,
+          env: this.env || '',
+          protocolVersion: packageFile.version,
+          erc1155NonTransferable: this.erc1155NonTransferable.address,
+        },
+        null,
+        2
+      ),
+      'utf-8'
+    );
+  }
+}
+
+export async function deploy(_env: string): Promise<void> {
+  const env = _env.toLowerCase();
+
+  if (!isValidEnv(env)) {
+    throw new Error(`Env: ${env} is not recognized!`);
+  }
+
+  const executor = new DeploymentExecutor();
+
+  await executor.deployContracts();
+
+  executor.logContracts();
+  executor.writeContracts();
+}

--- a/scripts/deploy-gate.ts
+++ b/scripts/deploy-gate.ts
@@ -1,6 +1,3 @@
-//AssetRegistry not used in demo-app
-//const AssetRegistry = artifacts.require("AssetRegistry");
-
 import hre from 'hardhat';
 import fs from 'fs';
 import {isValidEnv, addressesDirPath, getAddressesFilePath} from './utils';

--- a/scripts/deploy-legacy.ts
+++ b/scripts/deploy-legacy.ts
@@ -1,6 +1,3 @@
-//AssetRegistry not used in demo-app
-//const AssetRegistry = artifacts.require("AssetRegistry");
-
 import hre from 'hardhat';
 import fs from 'fs';
 import {isValidEnv, addressesDirPath, getAddressesFilePath} from './utils';
@@ -363,7 +360,7 @@ class DeploymentExecutor {
     }
 
     fs.writeFileSync(
-      getAddressesFilePath(hre.network.config.chainId, this.env),
+      getAddressesFilePath(hre.network.config.chainId, this.env, 'legacy'),
       JSON.stringify(
         {
           chainId: hre.network.config.chainId,

--- a/scripts/deploy-legacy.ts
+++ b/scripts/deploy-legacy.ts
@@ -354,16 +354,18 @@ class DeploymentExecutor {
     console.log('Boson Token Address Used: ', this.boson_token);
   }
 
-  writeContracts() {
+  async writeContracts() {
     if (!fs.existsSync(addressesDirPath)) {
       fs.mkdirSync(addressesDirPath);
     }
 
+    const chainId = (await hre.ethers.provider.getNetwork()).chainId;
+
     fs.writeFileSync(
-      getAddressesFilePath(hre.network.config.chainId, this.env, 'legacy'),
+      getAddressesFilePath(chainId, this.env, 'legacy'),
       JSON.stringify(
         {
-          chainId: hre.network.config.chainId,
+          chainId: chainId,
           env: this.env || '',
           protocolVersion: packageFile.version,
           tokenRegistry: this.tokenRegistry.address,

--- a/scripts/deploy-mocks.ts
+++ b/scripts/deploy-mocks.ts
@@ -79,7 +79,7 @@ class DeploymentExecutor {
       filePath,
       JSON.stringify(
         {
-          chainId: hre.network.config.chainId,
+          chainId: chainId,
           env: this.env || '',
           erc20: this.erc20,
           erc721: this.erc721,

--- a/scripts/deploy-mocks.ts
+++ b/scripts/deploy-mocks.ts
@@ -66,16 +66,15 @@ class DeploymentExecutor {
     this.erc1155NonTransferable = mockERC1155NonTransferableToken.address;
   }
 
-  writeContracts() {
+  async writeContracts() {
     if (!fs.existsSync(addressesDirPath)) {
       fs.mkdirSync(addressesDirPath);
     }
 
-    const filePath = getAddressesFilePath(
-      hre.network.config.chainId,
-      this.env,
-      'mocks'
-    );
+    const chainId = (await hre.ethers.provider.getNetwork()).chainId;
+
+    const filePath = getAddressesFilePath(chainId, this.env, 'mocks');
+
     fs.writeFileSync(
       filePath,
       JSON.stringify(
@@ -134,6 +133,6 @@ export async function deploy(_env: string): Promise<void> {
   async function deployMocks() {
     const executor = new DeploymentExecutor();
     await executor.deployMockTokens();
-    executor.writeContracts();
+    await executor.writeContracts();
   }
 }

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -302,16 +302,18 @@ class DeploymentExecutor {
     console.log('Boson Token Address Used: ', this.boson_token);
   }
 
-  writeContracts() {
+  async writeContracts() {
     if (!fs.existsSync(addressesDirPath)) {
       fs.mkdirSync(addressesDirPath);
     }
 
+    const chainId = (await hre.ethers.provider.getNetwork()).chainId;
+
     fs.writeFileSync(
-      getAddressesFilePath(hre.network.config.chainId, this.env),
+      getAddressesFilePath(chainId, this.env),
       JSON.stringify(
         {
-          chainId: hre.network.config.chainId,
+          chainId: chainId,
           env: this.env || '',
           protocolVersion: packageFile.version,
           tokenRegistry: this.tokenRegistry.address,
@@ -410,7 +412,7 @@ export async function deploy(_env: string): Promise<void> {
   await executor.deployMockToken(); //only deploys mock locally
 
   executor.logContracts();
-  executor.writeContracts();
+  await executor.writeContracts();
 
   await executor.setDefaults();
 }


### PR DESCRIPTION
- old script was renamed to `deploy-legacy`
- new `deploy` is more or less the same, expect all recerences to ERC1155 are removed
- I added another script to deploy ERC1155NonTransferable. Compared to `deploy-mocks` this script read metadata uri from .env and properly put it in the constructor
- I added the corresponding tasks, but I did not make additional scripts in `package.json` since I think it will become too clutered. Users can still call them using `npx hardhat [taskname]`