### PR TITLE
build: enhance deploy-gate.ts script

### DIFF
--- a/scripts/deploy-gate.ts
+++ b/scripts/deploy-gate.ts
@@ -109,14 +109,34 @@ class DeploymentExecutor {
       fs.mkdirSync(addressesDirPath);
     }
 
-    fs.writeFileSync(
-      getAddressesFilePath(hre.network.config.chainId, this.env, 'gate'),
-      JSON.stringify(
-        {
+    const gateAddressesFilePath = getAddressesFilePath(
+      hre.network.config.chainId,
+      this.env,
+      'gates'
+    );
+
+    const gateAddressesFileContent = fs.existsSync(gateAddressesFilePath)
+      ? JSON.parse(fs.readFileSync(gateAddressesFilePath, 'utf-8'))
+      : {
           chainId: hre.network.config.chainId,
           env: this.env || '',
           protocolVersion: packageFile.version,
-          gate: this.gate.address,
+          gates: [],
+        };
+
+    fs.writeFileSync(
+      gateAddressesFilePath,
+      JSON.stringify(
+        {
+          ...gateAddressesFileContent,
+          gates: [
+            ...gateAddressesFileContent.gates,
+            {
+              token: process.env.CONDITIONAL_TOKEN_ADDRESS,
+              tokenType: process.env.CONDITIONAL_TOKEN_TYPE,
+              gate: this.gate.address,
+            },
+          ],
         },
         null,
         2


### PR DESCRIPTION
This enhances the deploy-gate.ts script to add multiple gate/token pairs into a addresses file like
```json
{
  "chainId": 3,
  "env": "testing",
  "protocolVersion": "1.1.0-rc.1",
  "gates": [
    {
      "token": "0xf47E4fd9d2eBd6182F597eE12E487CcA37FC524c",
      "tokenType": "0",
      "gate": "0x77669a59220C1f015A8CcB8e9ad7C44c32738110"
    },
    {
      "token": "0xf47E4fd9d2eBd6182F597eE12E487CcA37FC524c",
      "tokenType": "0",
      "gate": "0xED239Ab6FEEEd5A005196A03E605aE734c68e288"
    }
  ]
}
```

The corresponding PR for the instances repo is this one https://github.com/bosonprotocol/instances/pull/4.