### PR TITLE
Package lock version update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@bosonprotocol/core",
-    "version": "1.1.0-rc.1",
+    "version": "1.1.0-rc.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {


### PR DESCRIPTION
When version in `package.json` was updated, new `package-lock.json` was not checked in.
Publishing to npm failed after tag vas created.
This PR resolves it.