### PR TITLE
Verify that deployed address matches calculated address

### DIFF
--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -247,7 +247,6 @@ class DeploymentExecutor {
     );
     await this.daiTokenWrapper.deployed();
     this.verifyDeployedAddress('daiTokenWrapper');
-
   }
 
   verifyDeployedAddress(contractName: string) {

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -186,12 +186,18 @@ class DeploymentExecutor {
     );
 
     this.tokenRegistry = await TokenRegistry.deploy(this.txOptions);
+    await this.tokenRegistry.deployed();
+    verifyDeployedAddress('TokenRegistry');
+
     this.voucherSets = await VoucherSets.deploy(
       process.env.VOUCHERSETS_METADATA_URI,
       contractAddresses.cashier,
       contractAddresses.voucherKernel,
       this.txOptions
     );
+    await this.voucherSets.deployed();
+    verifyDeployedAddress('VoucherSets');
+
     this.vouchers = await Vouchers.deploy(
       process.env.VOUCHERS_METADATA_URI,
       'Boson Smart Voucher',
@@ -200,6 +206,9 @@ class DeploymentExecutor {
       contractAddresses.voucherKernel,
       this.txOptions
     );
+    await this.vouchers.deployed();
+    verifyDeployedAddress('Vouchers');
+
     this.voucherKernel = await VoucherKernel.deploy(
       contractAddresses.br,
       contractAddresses.cashier,
@@ -207,6 +216,9 @@ class DeploymentExecutor {
       contractAddresses.vouchers,
       this.txOptions
     );
+    await this.voucherKernel.deployed();
+    verifyDeployedAddress('VoucherKernel');
+
     this.cashier = await Cashier.deploy(
       contractAddresses.br,
       contractAddresses.voucherKernel,
@@ -214,34 +226,35 @@ class DeploymentExecutor {
       contractAddresses.vouchers,
       this.txOptions
     );
+    await this.cashier.deployed();
+    verifyDeployedAddress('Cashier');
+
     this.br = await BosonRouter.deploy(
       contractAddresses.voucherKernel,
       contractAddresses.tokenRegistry,
       contractAddresses.cashier,
       this.txOptions
     );
+    await this.br.deployed();
+    verifyDeployedAddress('BosonRouter');
+
     this.daiTokenWrapper = await DAITokenWrapper.deploy(
       this.dai_token,
       this.txOptions
     );
-
-    await this.tokenRegistry.deployed();
-    await this.voucherSets.deployed();
-    await this.vouchers.deployed();
-    await this.voucherKernel.deployed();
-    await this.cashier.deployed();
-    await this.br.deployed();
     await this.daiTokenWrapper.deployed();
+    verifyDeployedAddress('TokenRegistry');
 
-    // check that expected and actual addresses match
-    for (const contract of contractList) {
+    function verifyDeployedAddress(contractName: string) {
+      // check that expected and actual addresses match
       if (
-        this[contract].address.toLowerCase() !==
-        contractAddresses[contract].toLowerCase()
+        this[contractName].address.toLowerCase() !==
+        contractAddresses[contractName].toLowerCase()
       ) {
         console.log(
-          `${contract} address mismatch. Expected ${contractAddresses[contract]}, actual ${this[contract].address}`
+          `${contractName} address mismatch. Expected ${contractAddresses[contractName]}, actual ${this[contractName].address}`
         );
+        process.exit(1);
       }
     }
   }

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -30,6 +30,7 @@ class DeploymentExecutor {
   erc1155NonTransferable;
   maxTip;
   txOptions;
+  contractAddresses;
 
   constructor() {
     if (this.constructor == DeploymentExecutor) {
@@ -185,9 +186,11 @@ class DeploymentExecutor {
       contractList
     );
 
+    this.contractAddresses = contractAddresses;
+
     this.tokenRegistry = await TokenRegistry.deploy(this.txOptions);
     await this.tokenRegistry.deployed();
-    verifyDeployedAddress('TokenRegistry');
+    this.verifyDeployedAddress('tokenRegistry');
 
     this.voucherSets = await VoucherSets.deploy(
       process.env.VOUCHERSETS_METADATA_URI,
@@ -196,7 +199,7 @@ class DeploymentExecutor {
       this.txOptions
     );
     await this.voucherSets.deployed();
-    verifyDeployedAddress('VoucherSets');
+    this.verifyDeployedAddress('voucherSets');
 
     this.vouchers = await Vouchers.deploy(
       process.env.VOUCHERS_METADATA_URI,
@@ -207,7 +210,7 @@ class DeploymentExecutor {
       this.txOptions
     );
     await this.vouchers.deployed();
-    verifyDeployedAddress('Vouchers');
+    this.verifyDeployedAddress('vouchers');
 
     this.voucherKernel = await VoucherKernel.deploy(
       contractAddresses.br,
@@ -217,7 +220,7 @@ class DeploymentExecutor {
       this.txOptions
     );
     await this.voucherKernel.deployed();
-    verifyDeployedAddress('VoucherKernel');
+    this.verifyDeployedAddress('voucherKernel');
 
     this.cashier = await Cashier.deploy(
       contractAddresses.br,
@@ -227,7 +230,7 @@ class DeploymentExecutor {
       this.txOptions
     );
     await this.cashier.deployed();
-    verifyDeployedAddress('Cashier');
+    this.verifyDeployedAddress('cashier');
 
     this.br = await BosonRouter.deploy(
       contractAddresses.voucherKernel,
@@ -236,26 +239,27 @@ class DeploymentExecutor {
       this.txOptions
     );
     await this.br.deployed();
-    verifyDeployedAddress('BosonRouter');
+    this.verifyDeployedAddress('br');
 
     this.daiTokenWrapper = await DAITokenWrapper.deploy(
       this.dai_token,
       this.txOptions
     );
     await this.daiTokenWrapper.deployed();
-    verifyDeployedAddress('TokenRegistry');
+    this.verifyDeployedAddress('daiTokenWrapper');
 
-    function verifyDeployedAddress(contractName: string) {
-      // check that expected and actual addresses match
-      if (
-        this[contractName].address.toLowerCase() !==
-        contractAddresses[contractName].toLowerCase()
-      ) {
-        console.log(
-          `${contractName} address mismatch. Expected ${contractAddresses[contractName]}, actual ${this[contractName].address}`
-        );
-        process.exit(1);
-      }
+  }
+
+  verifyDeployedAddress(contractName: string) {
+    // check that expected and actual addresses match
+    if (
+      this[contractName].address.toLowerCase() !==
+      this.contractAddresses[contractName].toLowerCase()
+    ) {
+      console.log(
+        `${contractName} address mismatch. Expected ${this.contractAddresses[contractName]}, actual ${this[contractName].address}`
+      );
+      process.exit(1);
     }
   }
 


### PR DESCRIPTION
In `deploy` we calculate some address upfront and pass them into constructors of other contracts.
If there exist some pending transactions from the deployer at the the begining of the deployment, calculated addresses are wrong.

Previously we only checked at the end of the deployment if calculated addresses actually match the deployed addresses.

Now I changed it to check right after the deployment and terminate the process if mismatch is detected.